### PR TITLE
ローカル開発でのdocker-composeファイル作成

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -5,6 +5,9 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('api');
+  if (process.env.ENABLED_CORS) {
+    app.enableCors();
+  }
 
   const options = new DocumentBuilder()
     .setTitle('ひまわりプロジェクト')

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -8,6 +8,12 @@ declare module 'vue/types/vue' {
 
 export default {
   mode: 'spa',
+  /**
+   * 環境変数
+   */
+  env: {
+    apiUrl: process.env.API_URL
+  },
   /*
    ** Headers of the page
    */

--- a/client/store/utils.ts
+++ b/client/store/utils.ts
@@ -2,8 +2,11 @@ import { BaseAPI } from '~/openapi/base'
 import { Configuration } from '~/openapi'
 
 export function buildApi<T extends BaseAPI>(Api: new (data: any) => T): T {
+  const basePath =
+    process.env.apiUrl ||
+    `${window.location.protocol}//${window.location.hostname}`
   const config = new Configuration({
-    basePath: `${window.location.protocol}//${window.location.hostname}`
+    basePath
   })
   return new Api(config)
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,65 @@
+version: "3"
+services:
+  client:
+    image: node:12.18.0-alpine
+    tty: true
+    working_dir: /app
+    volumes:
+      - ./client:/app
+    environment:
+      HOST: 0.0.0.0
+      # clientと違うホストの場合だけ指定するのだ
+      API_URL: http://localhost:3001
+    ports:
+      - "3000:3000"
+    restart: always
+    command: >
+      sh -c "npm install && npm run dev"
+    depends_on:
+      - "api"
+      - "db"
+  api:
+    image: node:12.18.0-alpine
+    tty: true
+    working_dir: /app
+    volumes:
+      - ./api:/app
+    ports:
+      - "3001:3000"
+    restart: always
+    command: >
+      sh -c "npm install && npm run start:dev"
+    environment:
+      ENABLED_CORS: 1
+      MYSQL_HOST: db
+      MYSQL_USERNAME: root
+      MYSQL_PASSWORD: root
+      MYSQL_DATABASE_NAME: api
+      MYSQL_PORT: 3306
+      MAIL_TRAP_USER: ${MAIL_TRAP_USER}
+      MAIL_TRAP_PASS: ${MAIL_TRAP_PASS}
+    depends_on:
+      - "db"
+  db:
+    image: mysql:5.7
+    volumes:
+      - mysql-db:/var/lib/mysql
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=api
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    ports:
+      - "8888:80"
+    environment:
+      PMA_HOST: db
+      PMA_PORT: 3306
+      MYSQL_ROOT_PASSWORD: root
+    depends_on:
+      - "db"
+
+volumes:
+  mysql-db:
+    driver: local


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/YmBIdSxn

## :memo: 概要
- PCのスペックやOSのバージョンにより、skaffoldが満足に動かないケースがでている
- ローカル環境にて`docker-compose up`だけで開発環境が動くようにする
  - volumeMountが使える分、skaffoldより早い、軽い
  - 本番インフラに近い形で開発が出来るのはskaffoldの強みではあるが、それはfujiwaraのPCで出来ていればある程度担保できるので、まあいい。

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] `skaffold dev`が今まで通り動くこと
- [x] ローカルのk8sまたは、minikubeをstopしたあと、`docker-compose up`で環境が立ち上がること
