### PR TITLE
docker-composeで、nuxtのhot reloadが効かない問題

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -79,5 +79,14 @@ export default {
         })
       }
     }
+  },
+  /**
+   * docker-composeでホットリロードが効かない問題の修正
+   * [FIY]https://github.com/nuxt/nuxt.js/issues/2481#issuecomment-356074552
+   */
+  watchers: {
+    webpack: {
+      poll: true
+    }
   }
 }


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/7e06cy7u

## :memo: 概要
- docker-composeで、nuxtのhot reloadが効かない問題を修正
- なぜか

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] docker-composeでnuxtのhot reloadが効くこと
