### PR TITLE
home,siginとsignupお互い遷移リンクを貼る

### DIFF
--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -7,10 +7,12 @@
         </vs-navbar-title>
       </div>
       <vs-navbar-item index="0">
-        <a href="#"><span class="navbar-login-text">ログイン</span></a>
+        <nuxt-link to="/users/signin"
+          ><span class="navbar-login-text">ログイン</span>
+        </nuxt-link>
       </vs-navbar-item>
       <vs-navbar-item index="1">
-        <a href="#"
+        <nuxt-link to="/users/signup"
           ><vs-button
             :color="gradiationButton.colorx"
             :gradient-color-secondary="gradiationButton.colorx2"
@@ -19,7 +21,7 @@
             size="small"
             ><span class="navbar-signup-text">登録する</span></vs-button
           >
-        </a>
+        </nuxt-link>
       </vs-navbar-item>
     </vs-navbar>
     <div class="main-image">

--- a/client/pages/users/signin.vue
+++ b/client/pages/users/signin.vue
@@ -10,7 +10,11 @@
     </vs-col>
     <vs-col vs-type="flex" vs-justify="flex-end" vs-w="6.5">
       <div class="nav">
-        <p>アカウントをお持ちでない方は<a href="/users/signup">こちら</a></p>
+        <p>
+          アカウントをお持ちでない方は<nuxt-link to="/users/signup"
+            >こちら</nuxt-link
+          >
+        </p>
       </div>
       <!-- フォームコンポーネント読み込み予定地 -->
     </vs-col>

--- a/client/pages/users/signup.vue
+++ b/client/pages/users/signup.vue
@@ -12,7 +12,11 @@
       <vs-row>
         <vs-col vs-type="flex" vs-justify="flex-end" vs-w="12">
           <div class="nav">
-            <p>すでにアカウントをお持ちの方は<a href="#">こちら</a></p>
+            <p>
+              すでにアカウントをお持ちの方は<nuxt-link to="/users/signin"
+                >こちら</nuxt-link
+              >
+            </p>
           </div>
         </vs-col>
         <vs-col vs-type="flex" vs-justify="center" vs-w="12">

--- a/client/test/pages/index.spec.ts
+++ b/client/test/pages/index.spec.ts
@@ -1,4 +1,4 @@
-import { mount, createLocalVue, config } from '@vue/test-utils'
+import { mount, createLocalVue, config, RouterLinkStub } from '@vue/test-utils'
 import Vuesax from 'vuesax'
 import Index from '@/pages/index.vue'
 
@@ -7,7 +7,12 @@ const localVue = createLocalVue()
 localVue.use(Vuesax as any)
 
 describe('IndexPage', () => {
-  const wrapper = mount(Index, { localVue })
+  const wrapper = mount(Index, {
+    localVue,
+    stubs: {
+      NuxtLink: RouterLinkStub
+    }
+  })
   it('is a Vue component', () => {
     expect(wrapper.isVueInstance()).toBeTruthy()
   })
@@ -23,7 +28,7 @@ describe('IndexPage', () => {
 
   it('ナビゲーションバーにログインボタンとユーザー登録ボタンがある', () => {
     const navbar = wrapper.find('.vs-navbar')
-    const navbarLinks = navbar.findAll('a')
+    const navbarLinks = navbar.findAll(RouterLinkStub)
     expect(navbarLinks.length).toBe(2)
     expect(navbarLinks.at(0).text()).toBe('ログイン')
     expect(navbarLinks.at(1).text()).toBe('登録する')

--- a/client/test/pages/index.spec.ts
+++ b/client/test/pages/index.spec.ts
@@ -31,6 +31,8 @@ describe('IndexPage', () => {
     const navbarLinks = navbar.findAll(RouterLinkStub)
     expect(navbarLinks.length).toBe(2)
     expect(navbarLinks.at(0).text()).toBe('ログイン')
+    expect(navbarLinks.at(0).props().to).toBe('/users/signin')
     expect(navbarLinks.at(1).text()).toBe('登録する')
+    expect(navbarLinks.at(1).props().to).toBe('/users/signup')
   })
 })

--- a/client/test/pages/users/signin.spec.ts
+++ b/client/test/pages/users/signin.spec.ts
@@ -16,4 +16,10 @@ describe('users/SigninPage', () => {
   it('is a Vue component', () => {
     expect(wrapper.isVueInstance()).toBeTruthy()
   })
+
+  it('ユーザー登録ページへのリンクがある', () => {
+    const link = wrapper.find(RouterLinkStub)
+    expect(link.text()).toBe('こちら')
+    expect(link.props().to).toBe('/users/signup')
+  })
 })

--- a/client/test/pages/users/signin.spec.ts
+++ b/client/test/pages/users/signin.spec.ts
@@ -1,4 +1,4 @@
-import { mount, createLocalVue, config } from '@vue/test-utils'
+import { mount, createLocalVue, config, RouterLinkStub } from '@vue/test-utils'
 import Vuesax from 'vuesax'
 import SigninPage from '@/pages/users/signin.vue'
 
@@ -7,7 +7,12 @@ const localVue = createLocalVue()
 localVue.use(Vuesax as any)
 
 describe('users/SigninPage', () => {
-  const wrapper = mount(SigninPage, { localVue })
+  const wrapper = mount(SigninPage, {
+    localVue,
+    stubs: {
+      NuxtLink: RouterLinkStub
+    }
+  })
   it('is a Vue component', () => {
     expect(wrapper.isVueInstance()).toBeTruthy()
   })

--- a/client/test/pages/users/signup.spec.ts
+++ b/client/test/pages/users/signup.spec.ts
@@ -1,4 +1,4 @@
-import { mount, createLocalVue, config } from '@vue/test-utils'
+import { mount, createLocalVue, config, RouterLinkStub } from '@vue/test-utils'
 import Vuesax from 'vuesax'
 import SignupPage from '@/pages/users/signup.vue'
 import SignupForm from '@/components/SignupForm.vue'
@@ -8,7 +8,12 @@ const localVue = createLocalVue()
 localVue.use(Vuesax as any)
 
 describe('users/SignupPage', () => {
-  const wrapper = mount(SignupPage, { localVue })
+  const wrapper = mount(SignupPage, {
+    localVue,
+    stubs: {
+      NuxtLink: RouterLinkStub
+    }
+  })
   it('is a Vue component', () => {
     expect(wrapper.isVueInstance()).toBeTruthy()
   })

--- a/client/test/pages/users/signup.spec.ts
+++ b/client/test/pages/users/signup.spec.ts
@@ -21,4 +21,10 @@ describe('users/SignupPage', () => {
   it('SignupFormコンポーネントをレンダーしている', () => {
     expect(wrapper.find(SignupForm).exists()).toBeTruthy()
   })
+
+  it('ログインページへのリンクがある', () => {
+    const link = wrapper.find(RouterLinkStub)
+    expect(link.text()).toBe('こちら')
+    expect(link.props().to).toBe('/users/signin')
+  })
 })


### PR DESCRIPTION
home,siginとsignupお互い遷移リンクを貼る

## :ticket: チケット
https://trello.com/c/HfB10pgA

## :memo: 概要
トップページの遷移リンク(nuxt-link)を貼る。
signupページにsgininリンク(nuxt-link)を貼る。
signinページにsignupリンク(nuxt-link)を貼る。

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
- [x] 各リンクをクリックすると対応したページへ遷移できる
- [x] CIが通ること
