### PR TITLE
fix: signIn()成功時のStatusCodeを201->200に修正

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   Res,
   Param,
+  HttpCode,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -50,6 +51,7 @@ export class AuthController {
   }
 
   @Post('/signin')
+  @HttpCode(200)
   @ApiOkResponse({
     type: AccessTokenSerializer,
     description: 'ユーザーログイン完了',


### PR DESCRIPTION
## :ticket: チケット
(trelloのチケットのリンクを貼りましょう)
https://trello.com/c/VRilmXSE

## :memo: 概要
(やった内容を書こう！)
signIn()成功時のstatus codeが201になっていたのを200に修正

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）
ロジックの修正

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] SwaggerのsignIn()でログイン成功時のResponseのCodeが200になっているか