### PR TITLE
目標作成画面の入力のバリデーションとエラーメッセージ

### DIFF
--- a/client/components/InputError.vue
+++ b/client/components/InputError.vue
@@ -1,9 +1,10 @@
 <template>
   <div>
-    <span v-if="errors.length" class="help is-danger">
-      {{ errors[0] }}
+    <span class="margin">
+      <span v-if="errors.length" class="help is-danger">
+        {{ errors[0] }}
+      </span>
     </span>
-    <span v-else class="help is-clear"><br /></span>
   </div>
 </template>
 
@@ -20,8 +21,11 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.is-danger {
+.margin {
   display: block;
+  height: 10px;
+}
+.is-danger {
   padding-top: 3px;
   color: #fa0000;
 }

--- a/client/components/pages/goals/CreateGoalsForm.vue
+++ b/client/components/pages/goals/CreateGoalsForm.vue
@@ -1,0 +1,195 @@
+<template>
+  <div>
+    <vs-row vs-justify="center">
+      <vs-col type="flex" vs-justify="center" vs-align="center" vs-w="6.6">
+        <vs-card class="cardx">
+          <div slot="header">
+            <vs-row vs-justify="flex-start">
+              <vs-col vs-offset="0.5" vs-type="flex">
+                <vs-icon
+                  icon="flag"
+                  class="main"
+                  color="#54a9fe"
+                  size="medium"
+                ></vs-icon>
+                <h1>
+                  新しい目標を作成する
+                </h1>
+              </vs-col>
+            </vs-row>
+            <vs-row>
+              <vs-col vs-offset="0.5" vs-w="11">
+                <vs-divider></vs-divider>
+              </vs-col>
+            </vs-row>
+            <validation-observer ref="observer" v-slot="{ invalid }" tag="form">
+              <vs-row class="goal">
+                <vs-col vs-w="5" vs-offset="0.7">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    rules="required|max:20"
+                    name="目標"
+                  >
+                    <h3>目標<span class="required">*</span></h3>
+                    <vs-input v-model="form.title" />
+                    <span class="error"><InputError :errors="errors"/></span>
+                  </validation-provider>
+                </vs-col>
+              </vs-row>
+              <vs-row class="description">
+                <vs-col vs-w="8" vs-offset="0.7">
+                  <h3>目標について</h3>
+                  <vs-textarea v-model="form.description" />
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-offset="0.5" vs-w="11">
+                  <vs-divider></vs-divider>
+                </vs-col>
+              </vs-row>
+              <vs-row class="public">
+                <vs-col vs-offset="1" vs-w="8">
+                  <vs-radio
+                    v-model="form.isPublic"
+                    vs-name="isPublic"
+                    :vs-value="true"
+                  >
+                    <vs-col vs-type="flex" vs-offset="0.2">
+                      <vs-icon
+                        icon="import_contacts"
+                        color="#606060"
+                        size="large"
+                      ></vs-icon>
+                      <vs-col vs-w="10" vs-offset="0.3">
+                        <h3>公開</h3>
+                        <p>
+                          誰でもこの目標を見ることができます。目標を公開にして、みんなと応援し合いましょう！
+                        </p>
+                      </vs-col>
+                    </vs-col>
+                  </vs-radio>
+                </vs-col>
+              </vs-row>
+              <vs-row class="public">
+                <vs-col vs-offset="1" vs-w="8">
+                  <vs-radio
+                    v-model="form.isPublic"
+                    vs-name="isPublic"
+                    :vs-value="false"
+                    checked="true"
+                  >
+                    <vs-row>
+                      <vs-col vs-type="flex" vs-offset="0.2">
+                        <vs-icon
+                          icon="https"
+                          color="#606060"
+                          size="large"
+                        ></vs-icon>
+                        <vs-col vs-w="10" vs-offset="0.3">
+                          <h3>非公開</h3>
+                          <p>
+                            この目標はあなたもしくは、グループメンバーしか見ることができません。
+                          </p>
+                        </vs-col>
+                      </vs-col>
+                    </vs-row>
+                  </vs-radio>
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-offset="0.5" vs-w="11">
+                  <vs-divider></vs-divider>
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-type="flex" vs-w="3" vs-offset="1">
+                  <vs-button
+                    color="#54a9fe"
+                    type="filled"
+                    :disabled="invalid"
+                    @click="handleSubmit"
+                    >目標を作成する
+                  </vs-button>
+                </vs-col>
+              </vs-row>
+            </validation-observer>
+          </div>
+        </vs-card>
+      </vs-col>
+    </vs-row>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import InputError from '@/components/InputError.vue'
+
+type Data = {
+  form: {
+    title: string // 目標の名前
+    description: string // 目標の詳細
+    isPublic: boolean // 公開設定
+  }
+}
+
+export default Vue.extend({
+  middleware: 'authenticated',
+  components: {
+    InputError
+  },
+  props: {
+    handleSubmit: {
+      type: Function,
+      default: () => {}
+    }
+  },
+  data() {
+    return {
+      form: {
+        title: '',
+        description: '',
+        isPublic: false
+      }
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+h1 {
+  color: #707070;
+  font-size: 36px;
+}
+.description {
+  margin-top: 30px;
+}
+.vs-input {
+  width: 100%;
+}
+.required {
+  color: #d00505;
+}
+.vs-icon {
+  padding-top: 10px;
+}
+.public {
+  .vs-raw {
+    width: 100%;
+  }
+}
+.public,
+.goal,
+.description {
+  h3 {
+    color: #707070;
+    font-size: 20px;
+  }
+  p {
+    color: #999999;
+    font-size: 16px;
+  }
+}
+.vs-button {
+  width: 100%;
+}
+</style>

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -176,10 +176,6 @@ h1 {
     width: 100%;
   }
 }
-span.error {
-  display: block;
-  height: 10px;
-}
 .public,
 .goal,
 .description {

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -25,7 +25,7 @@
             <validation-observer ref="observer" v-slot="{ invalid }" tag="form">
               <vs-row class="goal">
                 <vs-col vs-w="5" vs-offset="0.7">
-                  <validation-provider rules="required" name="目標">
+                  <validation-provider rules="required|max:20" name="目標">
                     <h3>目標<span class="required">*</span></h3>
                     <vs-input v-model="form.title" />
                   </validation-provider>

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -25,9 +25,14 @@
             <validation-observer ref="observer" v-slot="{ invalid }" tag="form">
               <vs-row class="goal">
                 <vs-col vs-w="5" vs-offset="0.7">
-                  <validation-provider rules="required|max:20" name="目標">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    rules="required|max:20"
+                    name="目標"
+                  >
                     <h3>目標<span class="required">*</span></h3>
                     <vs-input v-model="form.title" />
+                    <span class="error"><InputError :errors="errors"/></span>
                   </validation-provider>
                 </vs-col>
               </vs-row>
@@ -117,6 +122,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import InputError from '@/components/InputError.vue'
 
 type Data = {
   form: {
@@ -128,6 +134,9 @@ type Data = {
 
 export default Vue.extend({
   middleware: 'authenticated',
+  components: {
+    InputError
+  },
   data() {
     return {
       form: {
@@ -166,6 +175,10 @@ h1 {
   .vs-raw {
     width: 100%;
   }
+}
+span.error {
+  display: block;
+  height: 10px;
 }
 .public,
 .goal,

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -127,6 +127,7 @@ type Data = {
 }
 
 export default Vue.extend({
+  middleware: 'authenticated',
   data() {
     return {
       form: {

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -22,84 +22,92 @@
                 <vs-divider></vs-divider>
               </vs-col>
             </vs-row>
-            <vs-row class="goal">
-              <vs-col vs-w="5" vs-offset="0.7">
-                <h3>目標<span class="required">*</span></h3>
-                <vs-input v-model="form.title" />
-              </vs-col>
-            </vs-row>
-            <vs-row class="description">
-              <vs-col vs-w="8" vs-offset="0.7">
-                <h3>目標について</h3>
-                <vs-textarea v-model="form.description" />
-              </vs-col>
-            </vs-row>
-            <vs-row>
-              <vs-col vs-offset="0.5" vs-w="11">
-                <vs-divider></vs-divider>
-              </vs-col>
-            </vs-row>
-            <vs-row class="public">
-              <vs-col vs-offset="1" vs-w="8">
-                <vs-radio
-                  v-model="form.isPublic"
-                  vs-name="isPublic"
-                  :vs-value="true"
-                >
-                  <vs-col vs-type="flex" vs-offset="0.2">
-                    <vs-icon
-                      icon="import_contacts"
-                      color="#606060"
-                      size="large"
-                    ></vs-icon>
-                    <vs-col vs-w="10" vs-offset="0.3">
-                      <h3>公開</h3>
-                      <p>
-                        誰でもこの目標を見ることができます。目標を公開にして、みんなと応援し合いましょう！
-                      </p>
-                    </vs-col>
-                  </vs-col>
-                </vs-radio>
-              </vs-col>
-            </vs-row>
-            <vs-row class="public">
-              <vs-col vs-offset="1" vs-w="8">
-                <vs-radio
-                  v-model="form.isPublic"
-                  vs-name="isPublic"
-                  :vs-value="false"
-                  checked="true"
-                >
-                  <vs-row>
+            <validation-observer ref="observer" v-slot="{ invalid }" tag="form">
+              <vs-row class="goal">
+                <vs-col vs-w="5" vs-offset="0.7">
+                  <validation-provider rules="required" name="目標">
+                    <h3>目標<span class="required">*</span></h3>
+                    <vs-input v-model="form.title" />
+                  </validation-provider>
+                </vs-col>
+              </vs-row>
+              <vs-row class="description">
+                <vs-col vs-w="8" vs-offset="0.7">
+                  <h3>目標について</h3>
+                  <vs-textarea v-model="form.description" />
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-offset="0.5" vs-w="11">
+                  <vs-divider></vs-divider>
+                </vs-col>
+              </vs-row>
+              <vs-row class="public">
+                <vs-col vs-offset="1" vs-w="8">
+                  <vs-radio
+                    v-model="form.isPublic"
+                    vs-name="isPublic"
+                    :vs-value="true"
+                  >
                     <vs-col vs-type="flex" vs-offset="0.2">
                       <vs-icon
-                        icon="https"
+                        icon="import_contacts"
                         color="#606060"
                         size="large"
                       ></vs-icon>
                       <vs-col vs-w="10" vs-offset="0.3">
-                        <h3>非公開</h3>
+                        <h3>公開</h3>
                         <p>
-                          この目標はあなたもしくは、グループメンバーしか見ることができません。
+                          誰でもこの目標を見ることができます。目標を公開にして、みんなと応援し合いましょう！
                         </p>
                       </vs-col>
                     </vs-col>
-                  </vs-row>
-                </vs-radio>
-              </vs-col>
-            </vs-row>
-            <vs-row>
-              <vs-col vs-offset="0.5" vs-w="11">
-                <vs-divider></vs-divider>
-              </vs-col>
-            </vs-row>
-            <vs-row>
-              <vs-col vs-type="flex" vs-w="3" vs-offset="1">
-                <vs-button color="#54a9fe" type="filled" @click="onSubmit"
-                  >目標を作成する
-                </vs-button>
-              </vs-col>
-            </vs-row>
+                  </vs-radio>
+                </vs-col>
+              </vs-row>
+              <vs-row class="public">
+                <vs-col vs-offset="1" vs-w="8">
+                  <vs-radio
+                    v-model="form.isPublic"
+                    vs-name="isPublic"
+                    :vs-value="false"
+                    checked="true"
+                  >
+                    <vs-row>
+                      <vs-col vs-type="flex" vs-offset="0.2">
+                        <vs-icon
+                          icon="https"
+                          color="#606060"
+                          size="large"
+                        ></vs-icon>
+                        <vs-col vs-w="10" vs-offset="0.3">
+                          <h3>非公開</h3>
+                          <p>
+                            この目標はあなたもしくは、グループメンバーしか見ることができません。
+                          </p>
+                        </vs-col>
+                      </vs-col>
+                    </vs-row>
+                  </vs-radio>
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-offset="0.5" vs-w="11">
+                  <vs-divider></vs-divider>
+                </vs-col>
+              </vs-row>
+              <vs-row>
+                <vs-col vs-type="flex" vs-w="3" vs-offset="1">
+                  <vs-button
+                    color="#54a9fe"
+                    type="filled"
+                    :disabled="invalid"
+                    @click="onSubmit"
+                    >目標を作成する
+                  </vs-button>
+                </vs-col>
+              </vs-row>
+            </validation-observer>
           </div>
         </vs-card>
       </vs-col>

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -1,194 +1,27 @@
 <template>
   <div>
-    <vs-row vs-justify="center">
-      <vs-col type="flex" vs-justify="center" vs-align="center" vs-w="6.6">
-        <vs-card class="cardx">
-          <div slot="header">
-            <vs-row vs-justify="flex-start">
-              <vs-col vs-offset="0.5" vs-type="flex">
-                <vs-icon
-                  icon="flag"
-                  class="main"
-                  color="#54a9fe"
-                  size="medium"
-                ></vs-icon>
-                <h1>
-                  新しい目標を作成する
-                </h1>
-              </vs-col>
-            </vs-row>
-            <vs-row>
-              <vs-col vs-offset="0.5" vs-w="11">
-                <vs-divider></vs-divider>
-              </vs-col>
-            </vs-row>
-            <validation-observer ref="observer" v-slot="{ invalid }" tag="form">
-              <vs-row class="goal">
-                <vs-col vs-w="5" vs-offset="0.7">
-                  <validation-provider
-                    v-slot="{ errors }"
-                    rules="required|max:20"
-                    name="目標"
-                  >
-                    <h3>目標<span class="required">*</span></h3>
-                    <vs-input v-model="form.title" />
-                    <span class="error"><InputError :errors="errors"/></span>
-                  </validation-provider>
-                </vs-col>
-              </vs-row>
-              <vs-row class="description">
-                <vs-col vs-w="8" vs-offset="0.7">
-                  <h3>目標について</h3>
-                  <vs-textarea v-model="form.description" />
-                </vs-col>
-              </vs-row>
-              <vs-row>
-                <vs-col vs-offset="0.5" vs-w="11">
-                  <vs-divider></vs-divider>
-                </vs-col>
-              </vs-row>
-              <vs-row class="public">
-                <vs-col vs-offset="1" vs-w="8">
-                  <vs-radio
-                    v-model="form.isPublic"
-                    vs-name="isPublic"
-                    :vs-value="true"
-                  >
-                    <vs-col vs-type="flex" vs-offset="0.2">
-                      <vs-icon
-                        icon="import_contacts"
-                        color="#606060"
-                        size="large"
-                      ></vs-icon>
-                      <vs-col vs-w="10" vs-offset="0.3">
-                        <h3>公開</h3>
-                        <p>
-                          誰でもこの目標を見ることができます。目標を公開にして、みんなと応援し合いましょう！
-                        </p>
-                      </vs-col>
-                    </vs-col>
-                  </vs-radio>
-                </vs-col>
-              </vs-row>
-              <vs-row class="public">
-                <vs-col vs-offset="1" vs-w="8">
-                  <vs-radio
-                    v-model="form.isPublic"
-                    vs-name="isPublic"
-                    :vs-value="false"
-                    checked="true"
-                  >
-                    <vs-row>
-                      <vs-col vs-type="flex" vs-offset="0.2">
-                        <vs-icon
-                          icon="https"
-                          color="#606060"
-                          size="large"
-                        ></vs-icon>
-                        <vs-col vs-w="10" vs-offset="0.3">
-                          <h3>非公開</h3>
-                          <p>
-                            この目標はあなたもしくは、グループメンバーしか見ることができません。
-                          </p>
-                        </vs-col>
-                      </vs-col>
-                    </vs-row>
-                  </vs-radio>
-                </vs-col>
-              </vs-row>
-              <vs-row>
-                <vs-col vs-offset="0.5" vs-w="11">
-                  <vs-divider></vs-divider>
-                </vs-col>
-              </vs-row>
-              <vs-row>
-                <vs-col vs-type="flex" vs-w="3" vs-offset="1">
-                  <vs-button
-                    color="#54a9fe"
-                    type="filled"
-                    :disabled="invalid"
-                    @click="onSubmit"
-                    >目標を作成する
-                  </vs-button>
-                </vs-col>
-              </vs-row>
-            </validation-observer>
-          </div>
-        </vs-card>
-      </vs-col>
-    </vs-row>
+    <CreateGoalsForm :handle-submit="onSubmit" />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import InputError from '@/components/InputError.vue'
-
-type Data = {
-  form: {
-    title: string // 目標の名前
-    description: string // 目標の詳細
-    isPublic: boolean // 公開設定
-  }
-}
+import CreateGoalsForm from '@/components/pages/goals/CreateGoalsForm.vue'
 
 export default Vue.extend({
   middleware: 'authenticated',
   components: {
-    InputError
+    CreateGoalsForm
   },
   data() {
-    return {
-      form: {
-        title: '',
-        description: '',
-        isPublic: false
-      }
-    }
+    return {}
   },
   methods: {
     onSubmit() {
-      console.log(this.form)
+      alert('hogehoge')
     }
   }
 })
 </script>
 
-<style lang="scss" scoped>
-h1 {
-  color: #707070;
-  font-size: 36px;
-}
-.description {
-  margin-top: 30px;
-}
-.vs-input {
-  width: 100%;
-}
-.required {
-  color: #d00505;
-}
-.vs-icon {
-  padding-top: 10px;
-}
-.public {
-  .vs-raw {
-    width: 100%;
-  }
-}
-.public,
-.goal,
-.description {
-  h3 {
-    color: #707070;
-    font-size: 20px;
-  }
-  p {
-    color: #999999;
-    font-size: 16px;
-  }
-}
-.vs-button {
-  width: 100%;
-}
-</style>
+<style lang="scss" scoped></style>


### PR DESCRIPTION
## :ticket: チケット
目標作成画面の入力のバリデーションとエラーメッセージ

## :memo: 概要
目標欄にバリデーションを適用

## :stuck_out_tongue: やってないこと
エラーメッセージの表示場所が決まってなさそうなので表示していません。
必須なのはみたらわかるかなってのと文字数は
![Imgur](https://i.imgur.com/dij32C0.png)

こんな感じで視覚的にやりたかったんですけどtextareaしか対応してなくて悲しみ背負いました

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 必須と20文字以内のバリデーションがきのうしているかどうか(条件を満たしていなければ作成ボタンが押せない)
- [ ] 作成ボタンを押すとalertでhogehogeが表示される
