### PR TITLE
目標作成ページと作成APIの繋ぎ込み

### DIFF
--- a/client/components/pages/goals/CreateGoalsForm.vue
+++ b/client/components/pages/goals/CreateGoalsForm.vue
@@ -107,7 +107,7 @@
                     color="#54a9fe"
                     type="filled"
                     :disabled="invalid"
-                    @click="handleSubmit"
+                    @click="onSubmit"
                     >目標を作成する
                   </vs-button>
                 </vs-col>
@@ -150,6 +150,14 @@ export default Vue.extend({
         description: '',
         isPublic: false
       }
+    }
+  },
+  methods: {
+    async onSubmit() {
+      await this.handleSubmit(this.form)
+      this.form.title = ''
+      this.form.description = ''
+      this.form.isPublic = false
     }
   }
 })

--- a/client/components/pages/goals/CreateGoalsForm.vue
+++ b/client/components/pages/goals/CreateGoalsForm.vue
@@ -155,9 +155,6 @@ export default Vue.extend({
   methods: {
     async onSubmit() {
       await this.handleSubmit(this.form)
-      this.form.title = ''
-      this.form.description = ''
-      this.form.isPublic = false
     }
   }
 })

--- a/client/pages/goals/new.vue
+++ b/client/pages/goals/new.vue
@@ -7,6 +7,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import CreateGoalsForm from '@/components/pages/goals/CreateGoalsForm.vue'
+import { goalStore } from '@/store'
+import { CreateGoalDto } from '@/openapi'
 
 export default Vue.extend({
   middleware: 'authenticated',
@@ -17,8 +19,20 @@ export default Vue.extend({
     return {}
   },
   methods: {
-    onSubmit() {
-      alert('hogehoge')
+    async onSubmit(form: CreateGoalDto) {
+      console.log(form)
+      this.$vs.loading()
+      const { res, error, messages } = await goalStore.addGoal(form)
+      this.$vs.loading.close()
+
+      if (!error) {
+        this.$router.push(`/goals/${res.data.id}`)
+      } else if (error && messages) {
+        this.notify({
+          messages,
+          color: 'warning'
+        })
+      }
     }
   }
 })

--- a/client/store/modules/goal.ts
+++ b/client/store/modules/goal.ts
@@ -1,8 +1,13 @@
-import { Mutation, VuexModule, Module } from 'vuex-module-decorators'
-// import { buildApi } from '@/store/utils'
-// import { GoalsApi } from '~/openapi'
+import { Mutation, Action, VuexModule, Module } from 'vuex-module-decorators'
+import {
+  buildApi,
+  ActionAxiosResponse,
+  resSuccess,
+  resError
+} from '@/store/utils'
+import { GoalsApi, CreateGoalDto } from '~/openapi'
 
-// const goalApi = () => buildApi(GoalsApi)
+const goalApi = () => buildApi(GoalsApi)
 
 @Module({
   stateFactory: true,
@@ -19,5 +24,18 @@ export default class Goal extends VuexModule {
   @Mutation
   public SET_GOAL(goal: any) {
     this.goal = goal
+  }
+
+  @Action
+  public async addGoal(
+    createGoalDto: CreateGoalDto
+  ): Promise<ActionAxiosResponse> {
+    return await goalApi()
+      .goalsControllerCreateGoal(createGoalDto)
+      .then((res) => {
+        this.SET_GOAL([...this.goalsGetter, res.data])
+        return resSuccess(res)
+      })
+      .catch((e) => resError(e))
   }
 }

--- a/client/store/modules/goal.ts
+++ b/client/store/modules/goal.ts
@@ -33,7 +33,6 @@ export default class Goal extends VuexModule {
     return await goalApi()
       .goalsControllerCreateGoal(createGoalDto)
       .then((res) => {
-        this.SET_GOAL([...this.goalsGetter, res.data])
         return resSuccess(res)
       })
       .catch((e) => resError(e))


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/Fg5sWXdL

## :memo: 概要
/goals/new ページで目標作成ができるように
goal.tsにaddGoal Action追加

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] /goals/newページで目標の追加ができること
- [ ] /goals/_id にリダイレクトされること
- [ ] phpmyadminでgoalsテーブルを確認して正常に追加されていること
