### PR TITLE
初回に目標を作成したときに、画面遷移先で"isPublicがない"エラーになる問題を修正

### DIFF
--- a/client/pages/goals/_id/index.vue
+++ b/client/pages/goals/_id/index.vue
@@ -1,7 +1,7 @@
 <template>
   <vs-row vs-type="flex" vs-justify="center">
     <vs-col vs-w="8">
-      <GoalDetailHeader :goal="goal" />
+      <GoalDetailHeader v-if="goal" :goal="goal" />
       <vs-row vs-w="12" vs-type="flex" vs-justify="space-between">
         <h2 class="study-record">学習記録</h2>
         <vs-button


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/isvwhXkS

## :memo: 概要
- 初回に目標を作成したときに、画面遷移先で"isPublicがない"エラーになる問題を修正
- 具体的には、目標詳細画面に置いて、goalがnullになり得るのに、v-ifを書いていないのが問題でありました

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 初回ログイン時に、目標を作成してもエラーが出ないこと
