### PR TITLE
学習記録ページのバリデーション

### DIFF
--- a/client/components/molecules/TimeInputWithValidation.vue
+++ b/client/components/molecules/TimeInputWithValidation.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <vs-row>
+      <h3>{{ label }}</h3>
+      <RequiredChip />
+    </vs-row>
+    <div class="input-times">
+      <validation-provider :rules="rules" :name="label">
+        <vs-input
+          v-model="input.hours"
+          size="large"
+          type="number"
+          class="input-time"
+          min="0"
+          max="24"
+        />
+        <span>時間</span>
+        <!-- <InputError :errors="errors" /> -->
+      </validation-provider>
+      <validation-provider :rules="rules" :name="label">
+        <vs-input
+          v-model="input.minutes"
+          size="large"
+          type="number"
+          class="input-time"
+          min="0"
+          max="60"
+        />
+        <span>分</span>
+        <!-- <InputError :errors="errors" /> -->
+      </validation-provider>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+// import InputError from '@/components/atoms/InputError.vue'
+import RequiredChip from '@/components/atoms/RequiredChip.vue'
+
+type Value = {
+  hours: number
+  minutes: number
+}
+export default Vue.extend({
+  components: {
+    RequiredChip
+  },
+  props: {
+    value: {
+      type: Object as PropType<Value>,
+      required: true
+    },
+    rules: {
+      type: String,
+      default: ''
+    },
+    label: {
+      type: String,
+      default: ''
+    }
+  },
+  computed: {
+    input: {
+      get(): Value {
+        return this.value
+      },
+      set(input: Value) {
+        this.$emit('input', input)
+      }
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.input-times {
+  span {
+    display: inline-block;
+    margin: 0 0.5em;
+  }
+  .input-time {
+    width: 80px;
+    display: inline-block;
+  }
+}
+</style>

--- a/client/components/organisms/goals/index/CreateCommitDialog.vue
+++ b/client/components/organisms/goals/index/CreateCommitDialog.vue
@@ -26,7 +26,11 @@
           />
         </div>
         <div class="learning-times-box">
-          <TimeInput v-model="form.studyTime" label="学習時間" />
+          <TimeInputWithValiadtion
+            v-model="form.studyTime"
+            label="学習時間"
+            rules="required"
+          />
         </div>
         <div class="learning-content">
           <TextArea
@@ -52,14 +56,14 @@
 import Vue, { PropType } from 'vue'
 import { goalStore } from '@/store'
 import InputWithValidation from '@/components/molecules/InputWithValidation.vue'
-import TimeInput from '@/components/atoms/TimeInput.vue'
+import TimeInputWithValiadtion from '@/components/molecules/TimeInputWithValidation.vue'
 import TextArea from '@/components/atoms/TextArea.vue'
 // import SelectBowWithValidation from '@/components/molecules/SelectBoxWithValidation.vue'
 import { CreateCommitDto } from '@/openapi'
 
 export default Vue.extend({
   components: {
-    TimeInput,
+    TimeInputWithValiadtion,
     InputWithValidation,
     TextArea
     // SelectBowWithValidation
@@ -101,6 +105,21 @@ export default Vue.extend({
     async onSubmit() {
       if (!this.form.goalId) return
 
+      if (this.form.studyTime.hours + this.form.studyTime.minutes === 0) {
+        this.notify({
+          messages: ['学習時間は0にならないようにしてください'],
+          color: 'warning'
+        })
+        return
+      }
+      if (!this.form.studyTime.hours || this.form.studyTime.minutes) {
+        this.notify({
+          messages: ['数値を入力してください'],
+          color: 'warning'
+        })
+        return
+      }
+
       const createCommitDto: CreateCommitDto = {
         title: this.form.title,
         description: this.form.description || '',
@@ -111,7 +130,6 @@ export default Vue.extend({
         goalId: this.form.goalId,
         createCommitDto
       })
-
       if (error && messages) {
         this.notify({
           messages,
@@ -119,6 +137,10 @@ export default Vue.extend({
         })
       } else {
         this.input = false
+        this.form.title = ''
+        this.form.description = ''
+        this.form.studyTime.hours = 0
+        this.form.studyTime.minutes = 0
       }
     }
   }

--- a/client/components/organisms/goals/index/CreateCommitDialog.vue
+++ b/client/components/organisms/goals/index/CreateCommitDialog.vue
@@ -105,7 +105,11 @@ export default Vue.extend({
     async onSubmit() {
       if (!this.form.goalId) return
 
-      if (this.form.studyTime.hours + this.form.studyTime.minutes === 0) {
+      if (
+        Number(this.form.studyTime.hours) +
+          Number(this.form.studyTime.minutes) ===
+        0
+      ) {
         this.notify({
           messages: ['学習時間は0にならないようにしてください'],
           color: 'warning'


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/EbaPAK6J

## :memo: 概要
バリデーション難しすぎて敗北したのでnotifyで対応しました。

## :stuck_out_tongue: やってないこと
できれば入力時のバリデーションで対応したい・・・

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] /goals/:idページで学習の記録を入力するときに必須項目のバリデーションと学習時間の数値チェックが行われているか

