### PR TITLE
スマホでナビゲーションアイコンを押したときの背景の設定

### DIFF
--- a/client/components/organisms/layout/default/NavBar.vue
+++ b/client/components/organisms/layout/default/NavBar.vue
@@ -62,4 +62,7 @@ export default Vue.extend({})
   display: flex;
   align-items: center;
 }
+li {
+  background: white;
+}
 </style>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/hwjU2gec

## :memo: 概要
ナビゲーションアイコン押したときの背景の設定

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] ナビゲーションアイコンを押した時に背景が白になっていること
