### PR TITLE
[プロフィール編集]モーダルのモック作成

### DIFF
--- a/client/components/organisms/profile/ProfileEditDialog.vue
+++ b/client/components/organisms/profile/ProfileEditDialog.vue
@@ -9,24 +9,26 @@
       <v-form>
         <v-row>
           <v-col cols="4">
-            <v-img :src="require('@/assets/icon_sample.jpeg')">
-              <v-row align="end" class="lightbox white--text fill-height">
-                <v-col offset="10">
-                  <v-file-input
-                    label="avatar"
-                    filled
-                    hide-input
-                    prepend-icon="mdi-camera"
-                    accept="image/png, image/jpeg, image/bmp"
-                  ></v-file-input>
-                </v-col>
-              </v-row>
-            </v-img>
+            <v-img :src="require('@/assets/icon_sample.jpeg')" />
+            <v-file-input
+              label="Avatar Image"
+              outlined
+              dense
+              prepend-icon="mdi-camera"
+              accept="image/png, image/jpeg, image/bmp"
+              class="mt-5"
+            ></v-file-input>
           </v-col>
           <v-col cols="8">
             <v-row>
               <v-col cols="4">
-                <v-text-field label="ユーザー名" outlined dense required>
+                <v-text-field
+                  label="ユーザー名"
+                  outlined
+                  dense
+                  required
+                  class="mt-5"
+                >
                 </v-text-field>
               </v-col>
               <v-col cols="12">

--- a/client/components/organisms/profile/ProfileEditDialog.vue
+++ b/client/components/organisms/profile/ProfileEditDialog.vue
@@ -1,0 +1,59 @@
+<template>
+  <v-card>
+    <v-card-title class="headline">
+      <v-icon color="primary">account-box</v-icon>
+      プロフィール編集
+    </v-card-title>
+    <v-divider></v-divider>
+    <v-card-text>
+      <v-form>
+        <v-row>
+          <v-col cols="4">
+            <v-img :src="require('@/assets/icon_sample.jpeg')" />
+            <v-file-input
+              label="File input"
+              filled
+              hide-input
+              prepend-icon="mdi-camera"
+            ></v-file-input>
+          </v-col>
+          <v-col cols="8">
+            <v-row>
+              <v-col cols="4">
+                <p>ユーザー名</p>
+                <v-text-field label="ユーザー名" outlined required>
+                </v-text-field>
+              </v-col>
+              <v-col cols="12">
+                <p>ステータスメッセージ</p>
+                <v-textarea label="ステータスメッセージ" outlined></v-textarea>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+        <v-divider></v-divider>
+        <v-row>
+          <v-col cols="12">
+            <v-btn large color="primary" @click="onSubmit">
+              プロフィールを保存する
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      dialog: false
+    }
+  }
+})
+</script>
+
+<style></style>

--- a/client/components/organisms/profile/ProfileEditDialog.vue
+++ b/client/components/organisms/profile/ProfileEditDialog.vue
@@ -11,7 +11,7 @@
           <v-col cols="4">
             <v-img :src="require('@/assets/icon_sample.jpeg')" />
             <v-file-input
-              label="Avatar Image"
+              label="プロフィール画像"
               outlined
               dense
               prepend-icon="mdi-camera"

--- a/client/components/organisms/profile/ProfileEditDialog.vue
+++ b/client/components/organisms/profile/ProfileEditDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card>
     <v-card-title class="headline">
-      <v-icon color="primary">account-box</v-icon>
+      <v-icon large color="primary">mdi-account-box</v-icon>
       プロフィール編集
     </v-card-title>
     <v-divider></v-divider>
@@ -9,23 +9,27 @@
       <v-form>
         <v-row>
           <v-col cols="4">
-            <v-img :src="require('@/assets/icon_sample.jpeg')" />
-            <v-file-input
-              label="File input"
-              filled
-              hide-input
-              prepend-icon="mdi-camera"
-            ></v-file-input>
+            <v-img :src="require('@/assets/icon_sample.jpeg')">
+              <v-row align="end" class="lightbox white--text fill-height">
+                <v-col offset="10">
+                  <v-file-input
+                    label="avatar"
+                    filled
+                    hide-input
+                    prepend-icon="mdi-camera"
+                    accept="image/png, image/jpeg, image/bmp"
+                  ></v-file-input>
+                </v-col>
+              </v-row>
+            </v-img>
           </v-col>
           <v-col cols="8">
             <v-row>
               <v-col cols="4">
-                <p>ユーザー名</p>
-                <v-text-field label="ユーザー名" outlined required>
+                <v-text-field label="ユーザー名" outlined dense required>
                 </v-text-field>
               </v-col>
               <v-col cols="12">
-                <p>ステータスメッセージ</p>
                 <v-textarea label="ステータスメッセージ" outlined></v-textarea>
               </v-col>
             </v-row>
@@ -51,6 +55,11 @@ export default Vue.extend({
   data() {
     return {
       dialog: false
+    }
+  },
+  methods: {
+    onSubmit() {
+      alert('save profile')
     }
   }
 })

--- a/client/components/organisms/profile/ProfileEditDialog.vue
+++ b/client/components/organisms/profile/ProfileEditDialog.vue
@@ -52,11 +52,6 @@
 import Vue from 'vue'
 
 export default Vue.extend({
-  data() {
-    return {
-      dialog: false
-    }
-  },
   methods: {
     onSubmit() {
       alert('save profile')

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -15,7 +15,7 @@
       </v-col>
     </v-row>
 
-    <v-btn color="white" @click="profileEditDialog = true">
+    <v-btn color="white" block @click="profileEditDialog = true">
       プロフィール編集
     </v-btn>
     <v-dialog v-model="profileEditDialog" max-width="1000">

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -19,59 +19,7 @@
       プロフィール編集
     </v-btn>
     <v-dialog v-model="profileEditDialog" max-width="1000">
-      <!-- <ProfileEditDialog
-        :close-dialog="
-          () => {
-            profileEditDialog = false
-          }
-        "
-      /> -->
-      <v-card>
-        <v-card-title class="headline">
-          <v-icon color="primary">account-box</v-icon>
-          プロフィール編集
-        </v-card-title>
-        <v-divider></v-divider>
-        <v-card-text>
-          <v-form>
-            <v-row>
-              <v-col cols="4">
-                <v-img :src="require('@/assets/icon_sample.jpeg')" />
-                <v-file-input
-                  label="File input"
-                  filled
-                  hide-input
-                  prepend-icon="mdi-camera"
-                ></v-file-input>
-              </v-col>
-              <v-col cols="8">
-                <v-row>
-                  <v-col cols="4">
-                    <p>ユーザー名</p>
-                    <v-text-field label="ユーザー名" outlined required>
-                    </v-text-field>
-                  </v-col>
-                  <v-col cols="12">
-                    <p>ステータスメッセージ</p>
-                    <v-textarea
-                      label="ステータスメッセージ"
-                      outlined
-                    ></v-textarea>
-                  </v-col>
-                </v-row>
-              </v-col>
-            </v-row>
-            <v-divider></v-divider>
-            <v-row>
-              <v-col cols="12">
-                <v-btn large color="primary" @click="onSubmit">
-                  プロフィールを保存する
-                </v-btn>
-              </v-col>
-            </v-row>
-          </v-form>
-        </v-card-text>
-      </v-card>
+      <ProfileEditDialog />
     </v-dialog>
     <!-- PCのみ -->
     <v-divider v-show="_isPC" class="my-7"></v-divider>
@@ -139,11 +87,11 @@
 import Vue from 'vue'
 import { goalStore } from '@/store'
 import { CommitsSummary } from '@/openapi'
-// import ProfileEditDialog from '@/components/organisms/profile/ProfileEditDialog.vue'
+import ProfileEditDialog from '@/components/organisms/profile/ProfileEditDialog.vue'
 
 export default Vue.extend({
   components: {
-    // ProfileEditDialog
+    ProfileEditDialog
   },
   data() {
     return {

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -15,7 +15,64 @@
       </v-col>
     </v-row>
 
-    <v-btn color="white" block>プロフィール編集</v-btn>
+    <v-btn color="white" @click="profileEditDialog = true">
+      プロフィール編集
+    </v-btn>
+    <v-dialog v-model="profileEditDialog" max-width="1000">
+      <!-- <ProfileEditDialog
+        :close-dialog="
+          () => {
+            profileEditDialog = false
+          }
+        "
+      /> -->
+      <v-card>
+        <v-card-title class="headline">
+          <v-icon color="primary">account-box</v-icon>
+          プロフィール編集
+        </v-card-title>
+        <v-divider></v-divider>
+        <v-card-text>
+          <v-form>
+            <v-row>
+              <v-col cols="4">
+                <v-img :src="require('@/assets/icon_sample.jpeg')" />
+                <v-file-input
+                  label="File input"
+                  filled
+                  hide-input
+                  prepend-icon="mdi-camera"
+                ></v-file-input>
+              </v-col>
+              <v-col cols="8">
+                <v-row>
+                  <v-col cols="4">
+                    <p>ユーザー名</p>
+                    <v-text-field label="ユーザー名" outlined required>
+                    </v-text-field>
+                  </v-col>
+                  <v-col cols="12">
+                    <p>ステータスメッセージ</p>
+                    <v-textarea
+                      label="ステータスメッセージ"
+                      outlined
+                    ></v-textarea>
+                  </v-col>
+                </v-row>
+              </v-col>
+            </v-row>
+            <v-divider></v-divider>
+            <v-row>
+              <v-col cols="12">
+                <v-btn large color="primary" @click="onSubmit">
+                  プロフィールを保存する
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
     <!-- PCのみ -->
     <v-divider v-show="_isPC" class="my-7"></v-divider>
     <div v-show="_isSP" class="my-3"></div>
@@ -82,8 +139,17 @@
 import Vue from 'vue'
 import { goalStore } from '@/store'
 import { CommitsSummary } from '@/openapi'
+// import ProfileEditDialog from '@/components/organisms/profile/ProfileEditDialog.vue'
 
 export default Vue.extend({
+  components: {
+    // ProfileEditDialog
+  },
+  data() {
+    return {
+      profileEditDialog: false
+    }
+  },
   computed: {
     commitSummary(): CommitsSummary {
       return goalStore.commitSummaryGetter


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/fzLa0xX0

## :memo: 概要
プロフィール編集を押すと編集モーダルを表示

## :stuck_out_tongue: やってないこと
画像をアップロードするアイコンがzeplinにようにできてない


## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] himawari.dev/profileの「プロフィール編集」ボタンを押すと編集ダイアログが表示
- [ ] カメラアイコンをクリックでファイル選択可能（画像のみになっている）
- [ ] 保存するボタンクリックでアラート「save profile」が表示