### PR TITLE
タイムラインのダミーAPIとの繋ぎこみ

### DIFF
--- a/client/components/organisms/groups/_id/Timeline.vue
+++ b/client/components/organisms/groups/_id/Timeline.vue
@@ -3,8 +3,8 @@
     <v-col cols="12" md="10">
       <v-timeline align-top dense>
         <v-timeline-item
-          v-for="n in 4"
-          :key="n"
+          v-for="timeline in timelines"
+          :key="timeline"
           right="true"
           class="mainText--text mb-12"
         >
@@ -17,14 +17,19 @@
             <span>mm:ss</span>
           </template>
           <h5 class="mb-5">
-            username2 さんが 「目標タイトル」に 学習を記録しました。
+            {{
+              `ユーザーID:${timeline.commit.goal.userId}さんが「${timeline.commit.goal.title}」に学習を記録しました`
+            }}
           </h5>
           <v-card class="elevation-2">
             <v-card-title class="headline"
-              >TOEICで800点とるぞ！<v-spacer />
-              <span
-                ><v-icon color="primary">mdi-timer-outline</v-icon> 99h99m</span
-              >
+              >{{ timeline.commit.title }}<v-spacer />
+              <span>
+                <v-icon color="primary">mdi-timer-outline</v-icon>
+                {{
+                  `${timeline.commit.studyHours}h${timeline.commit.studyMinutes}m`
+                }}
+              </span>
               <v-btn icon class="mb-12">
                 <v-icon color="satisfyIcon">mdi-emoticon-outline</v-icon>
               </v-btn>
@@ -33,11 +38,7 @@
               </v-btn>
             </v-card-title>
             <v-card-text>
-              学習の記録内容が表示されます。
-              学習の記録内容が表示されます。学習の記録内容が表示されます。
-              学習の記録内容が表示されます。学習の記録内容が表示されます。学習の記録内容が表示されます。
-              学習の記録内容が表示されます。学習の記録内容が表示されます。
-              学習の記録内容が表示されます。
+              {{ timeline.commit.description }}
             </v-card-text>
           </v-card>
         </v-timeline-item>
@@ -48,6 +49,17 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { groupStore } from '@/store'
+import { CommitTimelineSerializer } from '@/openapi'
 
-export default Vue.extend({})
+export default Vue.extend({
+  data() {
+    return {}
+  },
+  computed: {
+    timelines(): CommitTimelineSerializer[] | null {
+      return groupStore.timelinesGetter
+    }
+  }
+})
 </script>

--- a/client/components/organisms/groups/_id/Timeline.vue
+++ b/client/components/organisms/groups/_id/Timeline.vue
@@ -57,7 +57,7 @@ export default Vue.extend({
     return {}
   },
   computed: {
-    timelines(): CommitTimelineSerializer[] | null {
+    timelines(): CommitTimelineSerializer[] {
       return groupStore.timelinesGetter
     }
   }

--- a/client/pages/groups/_id/index.vue
+++ b/client/pages/groups/_id/index.vue
@@ -10,6 +10,7 @@
 </template>
 <script lang="ts">
 import Vue from 'vue'
+import { groupStore } from '@/store'
 import TimelineHeader from '@/components/organisms/groups/_id/TimelineHeader.vue'
 import Timeline from '@/components/organisms/groups/_id/Timeline.vue'
 
@@ -18,6 +19,13 @@ export default Vue.extend({
   components: {
     Timeline,
     TimelineHeader
+  },
+  async created() {
+    this._startLoading()
+    const groupId = this.$route.params.id
+    // タイムライン情報情報の取得
+    await groupStore.getTimeline(Number(groupId))
+    this._finishLoading()
   }
 })
 </script>

--- a/client/store/modules/group.ts
+++ b/client/store/modules/group.ts
@@ -1,13 +1,21 @@
 import { Mutation, Action, VuexModule, Module } from 'vuex-module-decorators'
-import { buildApi, resSuccess, resError } from '@/store/utils'
+import {
+  buildApi,
+  resSuccess,
+  resError,
+  ActionAxiosResponse
+} from '@/store/utils'
 import {
   GroupsApi,
+  TimelinesApi,
   GroupSerializer,
+  CommitTimelineSerializer,
   InviteUserDto,
   CreateGroupDto
 } from '~/openapi'
 
 const groupApi = () => buildApi(GroupsApi)
+const timelinesApi = () => buildApi(TimelinesApi)
 
 @Module({
   stateFactory: true,
@@ -16,9 +24,19 @@ const groupApi = () => buildApi(GroupsApi)
 })
 export default class Group extends VuexModule {
   private group: GroupSerializer | null = null
+  private timelines: CommitTimelineSerializer[] | null = null
+
+  public get timelinesGetter() {
+    return this.timelines
+  }
 
   public get groupGetter() {
     return this.group
+  }
+
+  @Mutation
+  public SET_TIMELINES(timelines: CommitTimelineSerializer[] | null) {
+    this.timelines = timelines
   }
 
   @Mutation
@@ -51,5 +69,19 @@ export default class Group extends VuexModule {
         return resSuccess(res)
       })
       .catch((e) => resError(e))
+  }
+
+  @Action
+  public async getTimeline(id: number): Promise<ActionAxiosResponse> {
+    return await timelinesApi()
+      .timelinesControllerGetTimelines(id)
+      .then((res) => {
+        this.SET_TIMELINES(res.data)
+        return resSuccess(res)
+      })
+      .catch((e) => {
+        this.SET_TIMELINES(null)
+        return resError(e)
+      })
   }
 }

--- a/client/store/modules/group.ts
+++ b/client/store/modules/group.ts
@@ -24,7 +24,7 @@ const timelinesApi = () => buildApi(TimelinesApi)
 })
 export default class Group extends VuexModule {
   private group: GroupSerializer | null = null
-  private timelines: CommitTimelineSerializer[] | null = null
+  private timelines: CommitTimelineSerializer[] = []
 
   public get timelinesGetter() {
     return this.timelines
@@ -35,7 +35,7 @@ export default class Group extends VuexModule {
   }
 
   @Mutation
-  public SET_TIMELINES(timelines: CommitTimelineSerializer[] | null) {
+  public SET_TIMELINES(timelines: CommitTimelineSerializer[]) {
     this.timelines = timelines
   }
 
@@ -80,7 +80,7 @@ export default class Group extends VuexModule {
         return resSuccess(res)
       })
       .catch((e) => {
-        this.SET_TIMELINES(null)
+        this.SET_TIMELINES([])
         return resError(e)
       })
   }


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/1nTieSKC

## :memo: 概要
/groups/_id にアクセスしたときに表示されるタイムラインのコンポーネントをダミーのapiと繋いだ

## :stuck_out_tongue: やってないこと
ダミーのapiなのでユーザー名などがまだないので後ほど対応
日付ごとの表示やコミットした時間などの表示がまだ
目標達成などの仕様が決まっていないので現在はコミットの履歴だけ表示している

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] /groups/_idにアクセスして[ここ](https://app.zeplin.io/project/5eccb6802491e92a893422e9/screen/5eec2d880acee348007d2781)のようなデザインにやってないことなどを除いて近くなっているか
