### PR TITLE
タイムラインヘッダーAPI繋ぎこみ

### DIFF
--- a/client/components/organisms/groups/_id/Timeline.vue
+++ b/client/components/organisms/groups/_id/Timeline.vue
@@ -53,9 +53,6 @@ import { groupStore } from '@/store'
 import { CommitTimelineSerializer } from '@/openapi'
 
 export default Vue.extend({
-  data() {
-    return {}
-  },
   computed: {
     timelines(): CommitTimelineSerializer[] {
       return groupStore.timelinesGetter

--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -1,10 +1,13 @@
 <template>
-  <div class="d-flex justify-space-between cardGreyBg ma-0 pt-2 pb-2">
+  <div
+    v-if="group"
+    class="d-flex justify-space-between cardGreyBg ma-0 pt-2 pb-2"
+  >
     <div class="d-flex ml-3">
       <v-icon large left color="primary">
         mdi-account-group
       </v-icon>
-      <h2>グループ名</h2>
+      <h2>{{ group.name }}</h2>
     </div>
     <div class="d-flex mr-3">
       <v-text-field
@@ -16,13 +19,13 @@
         dense
       ></v-text-field>
       <v-avatar
-        v-for="(avatar, i) in 3"
-        :key="i"
+        v-for="user in group.users"
+        :key="user"
         color="indigo"
         size="36"
         class="ma-0"
       >
-        <span class="white--text headline">36</span>
+        <img src="http://i.pravatar.cc/64" />
       </v-avatar>
       <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>
       <v-btn color="white"><v-icon>mdi-cog</v-icon>設定</v-btn>
@@ -32,6 +35,13 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { groupStore } from '@/store'
 
-export default Vue.extend({})
+export default Vue.extend({
+  computed: {
+    group() {
+      return groupStore.groupGetter
+    }
+  }
+})
 </script>

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -63,7 +63,7 @@
       <v-list-item
         v-for="(group, index) in groups"
         :key="index"
-        :to="'/groups/' + group.id"
+        :to="`/groups/${group.id}`"
       >
         <v-list-item-avatar>
           <v-icon color="indigo">mdi-account-group</v-icon>

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -60,7 +60,11 @@
     <!-- PCのみ（スマホの場合は、サイドバーで見れるからかな） -->
     <v-list-item-group v-show="_isPC" v-if="groups.length" color="primary">
       <v-subheader>グループ</v-subheader>
-      <v-list-item v-for="(group, index) in groups" :key="index">
+      <v-list-item
+        v-for="(group, index) in groups"
+        :key="index"
+        :to="'/groups/' + group.id"
+      >
         <v-list-item-avatar>
           <v-icon color="indigo">mdi-account-group</v-icon>
         </v-list-item-avatar>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -40,7 +40,7 @@
           <v-list-item
             v-for="(group, index) in Iam.groups"
             :key="index"
-            :to="'/groups/' + group.id"
+            :to="`/groups/${group.id}`"
           >
             <v-list-item-content>
               <v-list-item-title v-text="group.name"></v-list-item-title>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -37,7 +37,11 @@
           color="primary"
         >
           <v-subheader>グループ</v-subheader>
-          <v-list-item v-for="(group, index) in Iam.groups" :key="index">
+          <v-list-item
+            v-for="(group, index) in Iam.groups"
+            :key="index"
+            :to="'/groups/' + group.id"
+          >
             <v-list-item-content>
               <v-list-item-title v-text="group.name"></v-list-item-title>
             </v-list-item-content>

--- a/client/pages/groups/_id/index.vue
+++ b/client/pages/groups/_id/index.vue
@@ -23,8 +23,11 @@ export default Vue.extend({
   async created() {
     this._startLoading()
     const groupId = this.$route.params.id
+    // グループの基本情報取得
+    await groupStore.getGroup(Number(groupId))
     // タイムライン情報情報の取得
     await groupStore.getTimeline(Number(groupId))
+
     this._finishLoading()
   }
 })

--- a/client/store/modules/group.ts
+++ b/client/store/modules/group.ts
@@ -65,6 +65,18 @@ export default class Group extends VuexModule {
   }
 
   @Action
+  public async getGroup(id: number) {
+    return await groupApi()
+      .groupsControllerGetGroup(id)
+      .then((res) => {
+        console.log(res.data)
+        this.SET_GROUP(res.data)
+        return resSuccess(res)
+      })
+      .catch((e) => resError(e))
+  }
+
+  @Action
   public async getGroups() {
     return await groupApi()
       .groupsControllerGetGroups()

--- a/client/store/modules/group.ts
+++ b/client/store/modules/group.ts
@@ -69,7 +69,6 @@ export default class Group extends VuexModule {
     return await groupApi()
       .groupsControllerGetGroup(id)
       .then((res) => {
-        console.log(res.data)
         this.SET_GROUP(res.data)
         return resSuccess(res)
       })


### PR DESCRIPTION
## :ticket: チケット
(trelloのチケットのリンクを貼りましょう)
https://trello.com/c/w16x2F0h
## :memo: 概要
(やった内容を書こう！)
API繋ぎ込み
グループ名とユーザーが正しく表示される（ユーザは人数のアイコンが出る）
## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] /groups/1にアクセスすると正しいグループ名とユーザーが正しく表示される
- [ ] プロフィールページ、サイドバーにてグループをクリックするとそのグループページに飛ぶ