### PR TITLE
リアクションの小さいカード作成

### DIFF
--- a/client/components/organisms/groups/_id/ReactionMenu.vue
+++ b/client/components/organisms/groups/_id/ReactionMenu.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="text-center">
+    <v-menu top offset-x>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn color="primary" icon v-bind="attrs" v-on="on">
+          <v-icon color="satisfyIcon">
+            mdi-emoticon-outline
+          </v-icon>
+        </v-btn>
+      </template>
+      <v-card>
+        <v-list>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title>
+                リアクションを選択
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+        <v-card-actions>
+          <v-btn
+            v-for="(item, index) in items"
+            :key="index"
+            icon
+            @click="onReaction()"
+            >{{ item.title }}</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-menu>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      items: [
+        { title: '👍' },
+        { title: '😄' },
+        { title: '🥺' },
+        { title: '🎉' }
+      ],
+      offset: true
+    }
+  },
+  methods: {
+    onReaction() {
+      alert('Action!!!!')
+    }
+  }
+})
+</script>
+
+<style></style>

--- a/client/components/organisms/groups/_id/Timeline.vue
+++ b/client/components/organisms/groups/_id/Timeline.vue
@@ -35,9 +35,9 @@
                   `${timeline.commit.studyHours}h${timeline.commit.studyMinutes}m`
                 }}
               </span>
-              <v-btn icon class="mb-12">
-                <v-icon color="satisfyIcon">mdi-emoticon-outline</v-icon>
-              </v-btn>
+              <div class="mb-12">
+                <ReactionMenu />
+              </div>
               <v-btn icon class="mb-12">
                 <v-icon>mdi-reply</v-icon>
               </v-btn>
@@ -56,8 +56,12 @@
 import Vue from 'vue'
 import { groupStore } from '@/store'
 import { CommitTimelineSerializer } from '@/openapi'
+import ReactionMenu from '@/components/organisms/groups/_id/ReactionMenu.vue'
 
 export default Vue.extend({
+  components: {
+    ReactionMenu
+  },
   computed: {
     timelines(): CommitTimelineSerializer[] {
       return groupStore.timelinesGetter


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/pLNueoR1

## :memo: 概要
グループのリアクションアイコンをクリックするとリアクションを選択するメニューが表示

## :stuck_out_tongue: やってないこと
アイコンの色がなんか薄いので要修正

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] グループにアクセスしてアイコンボタンクリックでメニューが表示される
- [x] メニュー内の絵文字アイコンをクリックするとアラートにて「Action!!!!」が表示される（どれ押しても同じです）
