### PR TITLE
目標詳細ページのスマホ画面対応

### DIFF
--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -20,6 +20,9 @@
       </div>
     </div>
     <v-divider class="mb-4"></v-divider>
+    <p v-show="_isSP" class="text-h4 primary--text font-weight-bold">
+      目標について
+    </p>
     <p class="text-subtitle-1">{{ goal.description }}</p>
   </div>
 </template>

--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -1,26 +1,24 @@
 <template>
   <div>
-    <v-row>
-      <v-col cols="10">
-        <p class="text-h4 font-weight-bold text-no-wrap">
-          <v-icon large>{{
-            !!goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline'
-          }}</v-icon
-          >{{ goal.title
-          }}<v-chip class="ma-2" color="chipBg">
-            <v-icon left color="challengingColor">mdi-fire</v-icon>
-            Challenging
-          </v-chip>
-        </p>
-      </v-col>
-      <v-row cols="2" justify="end" align-content="center" class="pr-7">
+    <div class="d-flex justify-space-between align-center pt-5">
+      <p class="text-h4 font-weight-bold text-no-wrap">
+        <v-icon v-show="_isPC" large>
+          {{ !!goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
+        </v-icon>
+        {{ _isPC ? goal.title : '' }}
+        <v-chip class="ma-2" color="chipBg">
+          <v-icon left color="challengingColor">mdi-fire</v-icon>
+          Challenging
+        </v-chip>
+      </p>
+      <div class="d-flex justify-end">
         <p class="mr-4">
           <v-icon color="primary">mdi-timer-outline</v-icon
           >{{ totalTime | toJPHm }}
         </p>
         <p><v-icon color="primary">mdi-pencil</v-icon>{{ commits.length }}</p>
-      </v-row>
-    </v-row>
+      </div>
+    </div>
     <v-divider class="mb-4"></v-divider>
     <p class="text-subtitle-1">{{ goal.description }}</p>
   </div>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -84,11 +84,23 @@
         v-show="_isSP"
         @click="drawerOpen = !drawerOpen"
       ></v-app-bar-nav-icon>
-      <v-toolbar-title><nuxt-link to="/">Project</nuxt-link></v-toolbar-title>
-      <v-col cols="3">
-        <!-- PCのみ -->
+      <!-- 目標詳細画面 && スマホ画面の時のみ、目標の名前を表示する -->
+      <v-container v-if="isGoalDetailPage && _isSP && _goal" fluid>
+        <v-row justify="center" class="mainText--text">
+          <v-toolbar-title>
+            <v-icon large>
+              {{ _goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
+            </v-icon>
+            {{ _goal.title || '' }}
+          </v-toolbar-title>
+        </v-row>
+      </v-container>
+      <v-toolbar-title v-else>
+        <nuxt-link to="/">Project</nuxt-link>
+      </v-toolbar-title>
+      <!-- PCのみ -->
+      <v-col v-show="_isPC" cols="3">
         <v-text-field
-          v-show="_isPC"
           class="ml-6"
           hide-details
           append-icon="mdi-magnify"
@@ -218,6 +230,13 @@ export default Vue.extend({
           }
         }
       ]
+    }
+  },
+  computed: {
+    isGoalDetailPage(): boolean {
+      const path = this.$route.path
+      const regex = /^\/goals\/\d+$/
+      return !!regex.test(path)
     }
   },
   methods: {

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -50,6 +50,7 @@ export default {
     '@/plugins/axios-accessor.ts',
     '@/plugins/filter.ts',
     '@/plugins/mixins/auth.ts',
+    '@/plugins/mixins/goal.ts',
     '@/plugins/mixins/loading.ts',
     '@/plugins/mixins/notifications.ts',
     '@/plugins/mixins/responsive.ts'

--- a/client/plugins/mixins/goal.ts
+++ b/client/plugins/mixins/goal.ts
@@ -1,0 +1,17 @@
+import Vue from 'vue'
+import { GoalSerializer } from '~/openapi'
+import { goalStore } from '~/store'
+
+const Goal = {
+  install(Vue: any, _: any) {
+    Vue.mixin({
+      computed: {
+        _goal(): GoalSerializer | null {
+          return goalStore.goalGetter
+        }
+      }
+    })
+  }
+}
+
+Vue.use(Goal)

--- a/client/vuetype.d.ts
+++ b/client/vuetype.d.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { UserSerializer } from './openapi'
+import { GoalSerializer, UserSerializer } from './openapi'
 import { NotificationItem } from '~/store/modules/notification'
 
 declare module 'vue/types/vue' {
@@ -8,6 +8,7 @@ declare module 'vue/types/vue' {
     isLoggedIn: boolean
     _isSP: boolean
     _isPC: boolean
+    _goal: GoalSerializer | null
     _startLoading: () => void
     _finishLoading: () => void
     _notifyyyy: (


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/t1kJDPZO

## :memo: 概要
- 目標詳細ページのスマホ画面対応をしました
- スマホ画面かつ目標詳細ページのときのみ、ヘッダーに目標タイトルを表示するようにしました
- 目標詳細ページのヘッダーのスタイルをzeplinと合わせました

![スクリーンショット 2020-07-15 1 42 58](https://user-images.githubusercontent.com/35862303/87453119-0658a980-c63d-11ea-9e21-f4946988a8d7.png)

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [x] スマホ画面かつ目標詳細ページのときのみ、ヘッダーに目標タイトルを表示されること
- [x] 目標詳細ページのヘッダーの目標タイトルは、PC画面の時だけ表示されること

