### PR TITLE
ユーザー登録時の認証メール文面のリッチ化

### DIFF
--- a/api/templates/completeRegistration.hbs
+++ b/api/templates/completeRegistration.hbs
@@ -1,5 +1,356 @@
-<b>{{username}}様</b>
-<br>
-本登録を完了してください。
-<br>
-<a href="{{url}}">[本登録URL]</a>
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mailtrap</title>
+    <style>
+      body{
+        height:100% !important;
+        margin:0;
+        padding:0;
+        width:100% !important;
+      }
+      img{
+        border:0;
+        outline:none;
+        text-decoration:none;
+      }
+      img{
+        width:auto;
+        max-width:100%;
+        display:block;
+      }
+      #btn-go{
+        width: 200px;
+        height: 50px;
+        border-radius: 8px;
+        border: solid 1px #54a9fe;
+        background-image: linear-gradient(to bottom, #db72e3, #81bbf5, #1996fe);
+      }
+      #bodyCell{
+          background-color: #eff7ff;
+      }
+      .btn-font{
+        width: 227px;
+        height: 37px;
+        font-family: Arial;
+        font-size: 13px;
+        font-weight: bold;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.14;
+        letter-spacing: normal;
+        text-align: left;
+        text-decoration: none;
+        color: #ffffff;
+      }
+      a:hover{
+        color:#009999 !important;
+      }
+      a:active{
+        color:#009999 !important;
+      }
+      a:visited{
+        color:#009999 !important;
+      }
+      .ReadMsgBody{
+        width:100%;
+      }
+      .ExternalClass{
+        width:100%;
+      }
+      img{
+        -ms-interpolation-mode:bicubic;
+      }
+      body{
+        -ms-text-size-adjust:100%;
+        -webkit-text-size-adjust:100%;
+      }
+      body{
+        font-family:Arial,sans-serif;
+        font-size:16px;
+        font-weight:normal;
+        line-height:24px;
+        color:#4A4A4A;
+      }
+      body{
+        background-color:#f4f4f4;
+      }
+      .btn a:hover{
+        color:#fff !important;
+      }
+      .btn a:active{
+        color:#fff !important;
+      }
+      .btn a:visited{
+        color:#fff !important;
+      }
+      @media only screen and (max-width: 600px){
+          body{
+              width:100% !important;
+              min-width:100% !important;
+              background-color: #ffffff !important;
+          }
+      }	@media only screen and (max-width: 600px){
+              body{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              table{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              td{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              p{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              a{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              li{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              blockquote{
+                  -webkit-text-size-adjust:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              table{
+                  max-width:580px !important;
+                  width:100% !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              #bodyTable{
+                  background-color: #ffffff !important;
+              }
+
+      } @media only screen and (max-width: 600px){
+              #bodyCell{
+                  padding:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-22{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-65{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-78{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-25{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-50{
+                  display:block !important;
+                  width:100% !important;
+                  padding:0 0 15px !important;
+                  box-sizing:border-box;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-22:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-65:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-78:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-25:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .column-50:last-child{
+                  padding-bottom:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .header-logo{
+                  padding:15px !important;
+              }
+
+      } @media only screen and (max-width: 600px){
+              .header{
+                  padding:20px !important;
+                  border-radius:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .section{
+                  padding:20px !important;
+                  border-radius:0 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .header{
+                  background:#3F3D55 !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .product-block{
+                  background:#04158E !important;
+              }
+
+      } @media only screen and (max-width: 600px){
+              .footer .icon-text{
+                  display:none !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .is-fittogrid{
+                  width:100% !important;
+                  height:auto !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+              .mobile-centered-container{
+                  text-align:center !important;
+              }
+
+      }	@media only screen and (max-width: 600px){
+        .mobile-centered-item{
+          display:inline-block !important;
+        }
+      }
+  </style>
+  </head>
+  <body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #f4f4f4; color: #4A4A4A; font-family: Arial, sans-serif; font-size: 16px; font-weight: normal; height: 100% !important; line-height: 24px; margin: 0; padding: 0; width: 100% !important" bgcolor="#f4f4f4">
+    <center>
+      <table border="0" cellpadding="0" cellspacing="0" width="100%" id="bodyTable" style="height:100% !important;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background:#f4f4f4;border-collapse:collapse;color:#4A4A4A;font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:24px;margin:0;mso-table-lspace:0pt;mso-table-rspace:0pt;padding:0;width:100% !important;" bgcolor="#f4f4f4">
+        <tbody>
+          <tr>
+            <td align="center" valign="top" id="bodyCell" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;height:100% !important;margin:0;mso-table-lspace:0pt;mso-table-rspace:0pt;padding:20px;width:100% !important;">
+              <!-- // BEGIN EMAIL -->
+              <table border="0" cellpadding="0" cellspacing="0" width="70%" class="main" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+                <tbody>
+                    <tr>
+                      <td align="left" valign="top" class="section is-top-merged" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background:#fff;border-radius:0 0 5px 5px;mso-table-lspace:0pt;mso-table-rspace:0pt;padding:20px 50px 40px;" bgcolor="#ffffff">
+                        <!-- Content section -->
+                        <table border="0" cellpadding="0" cellspacing="0" width="100%" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+                          <tbody>
+                            <tr>
+                              <td align="left" valign="top" class="content-item" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding-bottom:25px;">
+                                <h1 style="color:#4A4A4A;font-size:24px;letter-spacing:-.7px;line-height:29px;margin:0;padding:0;">
+                                  <span class="highlighted-text" style="color: #000">{{username}}</span>
+                                </h1>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" valign="top" class="content-item" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding-bottom:25px;">
+                                <!-- // Example block // -->
+                                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+                                  <tbody>
+                                    <tr>
+                                      <td align="left" valign="top" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+                                        <p> HimawariHubへの登録を完了するには、メールアドレスの確認が必要です。<br/>
+                                            以下のボタンからご登録いただいたメールアドレスの認証を完了してください。</p>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <table border="0" cellpadding="0" cellspacing="0" align="left" class="btn" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;border-collapse:separate;mso-table-lspace:0pt;mso-table-rspace:0pt;margin-bottom: 40px;">
+                                        <tbody>
+                                          <tr>
+                                            <td align="center" valign="left" id="btn-go">
+                                              <a class="btn-font" href="{{url}}" target="_blank">メールアドレスの確認</a>
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                </td>
+                            </tr>
+                            <tr>
+                              <td align="left" valign="top" class="content-item" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;mso-table-lspace:0pt;mso-table-rspace:0pt;padding-bottom:25px;">
+                                <p style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;margin:0;"> ボタンが機能しませんか? 次のリンクをブラウザに貼り付けます。<br/>
+                                    {{url}}<br/><br/>
+          
+          
+                                    ※このメールはHimawariHubアカウントへご登録いただいた方へお送りしています。<br/>
+                                    心当たりがない方はお手数ですが、その旨を明記しHimawariHubまでお問い合わせください。<br/>
+                                    お問い合わせはこちらから https://www.himawari.com/??????<br/></p>
+                              </td>
+                            </tr>
+                            <tr>
+                                <td align="center" valign="top" class="footer-heading" style="-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background:url('https://gallery.mailchimp.com/bfdf3c6997809dba3c6682bcf/images/cabdbec1-8813-44da-b186-baec3b4f5bbd.png') repeat-x top;background-size:20px;mso-table-lspace:0pt;mso-table-rspace:0pt;padding-bottom:25px;">
+                                    <p style="background:#ffffff;color:#4A4A4A;display:inline-block;font-size:16px;letter-spacing:-.53px;line-height:20px;margin:0;padding:0 10px;"></p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center" valign="top">COPYRIGHT @ 2020 Himawarigumi, All rights Reserved</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <!-- END EMAIL // -->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </center>
+    </body>
+</html>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/eAGFMCA8

## :memo: 概要
ユーザー登録時の認証メール文面のリッチ化

## :stuck_out_tongue: やってないこと
zepinのような画像が貼っていない

## :heavy_check_mark: 動作確認
- [x] 新規登録する時、確認用メールの表示はzepin(画像除く)のようなリッチ化した画面になる
- [x] CIが通ること
