### PR TITLE
タイムラインヘッダーのアバターが全てログインユーザーのものになっていた修正

### DIFF
--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -25,11 +25,11 @@
         size="36"
         class="ma-0"
       >
-        <v-img v-if="Iam.avatarUrl" :src="Iam.avatarUrl" />
+        <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
         <svg
           v-else
           viewBox="0 0 640 640"
-          v-html="jdenticonSvg(Iam.email)"
+          v-html="jdenticonSvg(user.email)"
         ></svg>
       </v-avatar>
       <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/UaRaLphN

## :memo: 概要
タイムラインヘッダーのアバターが全てログインユーザーのものになっていた修正しました
<img width="345" alt="スクリーンショット 2020-07-20 11 08 25" src="https://user-images.githubusercontent.com/35862303/87892912-568a9e00-ca79-11ea-814b-6dda0fbb91ca.png">

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] グループタイムラインヘッダー部分にて、参加ユーザーそれぞれのアバターが表示されていること
