### PR TITLE
[WIP] NavBarの検索プルダウン作成

### DIFF
--- a/client/components/organisms/layout/default/SearchAutocomplete.vue
+++ b/client/components/organisms/layout/default/SearchAutocomplete.vue
@@ -1,0 +1,89 @@
+<template>
+  <v-autocomplete
+    v-model="autocomplete"
+    class="ml-6"
+    :items="autocompleteItem"
+    :loading="loading"
+    :search-input.sync="search"
+    dense
+    label="Search"
+    filled
+    rounded
+    hide-details
+    item-text="name"
+    item-value="name"
+  >
+    <template v-slot:selection="{ attr, on, item }">
+      <v-icon left>mdi-coin</v-icon>
+      <span v-text="item.name"></span>
+    </template>
+    <!-- 検索結果が無い、もしくはデータ取得ができないとき表示 -->
+    <template v-slot:no-data>
+      <v-list-item>
+        <v-list-item-title>
+          一致するものがないか見つかりません
+          <strong>🥺ぴえん🥺</strong>
+        </v-list-item-title>
+      </v-list-item>
+    </template>
+    <!-- 検索するデータ群 -->
+    <template v-slot:item="{ item }">
+      <v-list-item-avatar
+        v-if="item.group === 'user'"
+        class="headline font-weight-light white--text"
+      >
+        <v-img v-if="item.avatarUrl" :src="Iam.avatarUrl" />
+        <svg
+          v-else
+          viewBox="0 0 640 640"
+          v-html="jdenticonSvg(item.name)"
+        ></svg>
+      </v-list-item-avatar>
+      <v-list-item-icon v-else>
+        <v-icon v-if="item.isPublic">mdi-earth</v-icon>
+        <v-icon v-else>mdi-lock-outline</v-icon>
+      </v-list-item-icon>
+      <v-list-item-content>
+        <v-list-item-title v-html="item.name"></v-list-item-title>
+      </v-list-item-content>
+      <v-list-item-action>
+        <v-icon>mdi-coin</v-icon>
+      </v-list-item-action>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      autocompleteItem: [
+        { header: 'ユーザー' },
+        {
+          name: 'ニャンコ先生',
+          avatarUrl:
+            'https://res.cloudinary.com/db32y726v/image/upload/v1594956272/llry2sr3t4gnpsifyofe.jpg',
+          group: 'user'
+        },
+        { name: 'Ali Connors', avatarUrl: '', group: 'user' },
+        { name: 'Trevor Hansen', avatarUrl: '', group: 'user' },
+        { name: 'Tucker Smith', avatarUrl: '', group: 'user' },
+        { divider: true },
+        { header: '目標' },
+        { name: '目標サンプル1', isPublic: true, group: 'goals' },
+        { name: '目標サンプル2 ', isPublic: false, group: 'goals' },
+        { name: 'John Smith', isPublic: false, group: 'goals' },
+        { name: 'Sandra Williams', isPublic: true, group: 'goals' }
+      ],
+      autocomplete: null,
+      search: null,
+      select: null,
+      loading: false
+    }
+  }
+})
+</script>
+
+<style></style>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -100,14 +100,66 @@
       </v-toolbar-title>
       <!-- PCのみ -->
       <v-col v-show="_isPC" cols="3">
-        <v-text-field
+        <!-- <v-text-field
           class="ml-6"
           hide-details
           append-icon="mdi-magnify"
           filled
           dense
           rounded
-        ></v-text-field>
+        ></v-text-field> -->
+        <v-autocomplete
+          v-model="autocomplete"
+          class="ml-6"
+          :items="autocompleteItem"
+          :loading="loading"
+          :search-input.sync="search"
+          dense
+          label="Search"
+          filled
+          rounded
+          hide-details
+          item-text="name"
+          item-value="name"
+        >
+          <template v-slot:selection="{ attr, on, item }">
+            <v-icon left>mdi-coin</v-icon>
+            <span v-text="item.name"></span>
+          </template>
+          <!-- 検索結果が無い、もしくはデータ取得ができないとき表示 -->
+          <template v-slot:no-data>
+            <v-list-item>
+              <v-list-item-title>
+                一致するものがないか見つかりません
+                <strong>🥺ぴえん🥺</strong>
+              </v-list-item-title>
+            </v-list-item>
+          </template>
+          <!-- 検索するデータ群 -->
+          <template v-slot:item="{ item }">
+            <v-list-item-avatar
+              v-if="item.group === 'user'"
+              class="headline font-weight-light white--text"
+            >
+              <v-img v-if="item.avatarUrl" :src="Iam.avatarUrl" />
+              <svg
+                v-else
+                viewBox="0 0 640 640"
+                v-html="jdenticonSvg(item.name)"
+              ></svg>
+            </v-list-item-avatar>
+            <v-list-item-icon v-else>
+              <v-icon v-if="item.isPublic">mdi-earth</v-icon>
+              <v-icon v-else>mdi-lock-outline</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title v-html="item.name"></v-list-item-title>
+            </v-list-item-content>
+            <v-list-item-action>
+              <v-icon>mdi-coin</v-icon>
+            </v-list-item-action>
+          </template>
+        </v-autocomplete>
       </v-col>
       <v-spacer></v-spacer>
       <!-- PCのみ -->
@@ -229,7 +281,29 @@ export default Vue.extend({
             ])
           }
         }
-      ]
+      ],
+      autocompleteItem: [
+        { header: 'ユーザー' },
+        {
+          name: 'ニャンコ先生',
+          avatarUrl:
+            'https://res.cloudinary.com/db32y726v/image/upload/v1594956272/llry2sr3t4gnpsifyofe.jpg',
+          group: 'user'
+        },
+        { name: 'Ali Connors', avatarUrl: '', group: 'user' },
+        { name: 'Trevor Hansen', avatarUrl: '', group: 'user' },
+        { name: 'Tucker Smith', avatarUrl: '', group: 'user' },
+        { divider: true },
+        { header: '目標' },
+        { name: '目標サンプル1', isPublic: true, group: 'goals' },
+        { name: 'Jane Smith ', isPublic: false, group: 'goals' },
+        { name: 'John Smith', isPublic: false, group: 'goals' },
+        { name: 'Sandra Williams', isPublic: true, group: 'goals' }
+      ],
+      autocomplete: null,
+      search: null,
+      select: null,
+      loading: false
     }
   },
   computed: {

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -100,66 +100,7 @@
       </v-toolbar-title>
       <!-- PCのみ -->
       <v-col v-show="_isPC" cols="3">
-        <!-- <v-text-field
-          class="ml-6"
-          hide-details
-          append-icon="mdi-magnify"
-          filled
-          dense
-          rounded
-        ></v-text-field> -->
-        <v-autocomplete
-          v-model="autocomplete"
-          class="ml-6"
-          :items="autocompleteItem"
-          :loading="loading"
-          :search-input.sync="search"
-          dense
-          label="Search"
-          filled
-          rounded
-          hide-details
-          item-text="name"
-          item-value="name"
-        >
-          <template v-slot:selection="{ attr, on, item }">
-            <v-icon left>mdi-coin</v-icon>
-            <span v-text="item.name"></span>
-          </template>
-          <!-- 検索結果が無い、もしくはデータ取得ができないとき表示 -->
-          <template v-slot:no-data>
-            <v-list-item>
-              <v-list-item-title>
-                一致するものがないか見つかりません
-                <strong>🥺ぴえん🥺</strong>
-              </v-list-item-title>
-            </v-list-item>
-          </template>
-          <!-- 検索するデータ群 -->
-          <template v-slot:item="{ item }">
-            <v-list-item-avatar
-              v-if="item.group === 'user'"
-              class="headline font-weight-light white--text"
-            >
-              <v-img v-if="item.avatarUrl" :src="Iam.avatarUrl" />
-              <svg
-                v-else
-                viewBox="0 0 640 640"
-                v-html="jdenticonSvg(item.name)"
-              ></svg>
-            </v-list-item-avatar>
-            <v-list-item-icon v-else>
-              <v-icon v-if="item.isPublic">mdi-earth</v-icon>
-              <v-icon v-else>mdi-lock-outline</v-icon>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title v-html="item.name"></v-list-item-title>
-            </v-list-item-content>
-            <v-list-item-action>
-              <v-icon>mdi-coin</v-icon>
-            </v-list-item-action>
-          </template>
-        </v-autocomplete>
+        <SearchAutocomplete />
       </v-col>
       <v-spacer></v-spacer>
       <!-- PCのみ -->
@@ -238,12 +179,14 @@ import { authStore } from '@/store'
 import Loading from '@/components/molecules/Loading.vue'
 import Notifications from '@/components/molecules/Notifications.vue'
 import CreateCommitDialog from '@/components/organisms/layout/default/CreateCommitDialog.vue'
+import SearchAutocomplete from '@/components/organisms/layout/default/SearchAutocomplete.vue'
 
 export default Vue.extend({
   components: {
     Loading,
     Notifications,
-    CreateCommitDialog
+    CreateCommitDialog,
+    SearchAutocomplete
   },
   data() {
     return {
@@ -281,29 +224,7 @@ export default Vue.extend({
             ])
           }
         }
-      ],
-      autocompleteItem: [
-        { header: 'ユーザー' },
-        {
-          name: 'ニャンコ先生',
-          avatarUrl:
-            'https://res.cloudinary.com/db32y726v/image/upload/v1594956272/llry2sr3t4gnpsifyofe.jpg',
-          group: 'user'
-        },
-        { name: 'Ali Connors', avatarUrl: '', group: 'user' },
-        { name: 'Trevor Hansen', avatarUrl: '', group: 'user' },
-        { name: 'Tucker Smith', avatarUrl: '', group: 'user' },
-        { divider: true },
-        { header: '目標' },
-        { name: '目標サンプル1', isPublic: true, group: 'goals' },
-        { name: 'Jane Smith ', isPublic: false, group: 'goals' },
-        { name: 'John Smith', isPublic: false, group: 'goals' },
-        { name: 'Sandra Williams', isPublic: true, group: 'goals' }
-      ],
-      autocomplete: null,
-      search: null,
-      select: null,
-      loading: false
+      ]
     }
   },
   computed: {


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/o0oc5h1W

## :memo: 概要
autocompletesを使ってそれっぽいのを実装
ユーザーと目標を分けて表示（ダミー）

## :stuck_out_tongue: やってないこと
日本語が完全一致検索でしか探せない、Googleの検索みたいなことができません！（軽く調べたらそういう日本語のライブラリ入れたらいけるっぽい？）
全体検索のボタン未実装
候補を選択したときにそれっぽいアラート表示

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] 検索フォームにフォーカスするとリスト表示
- [x] 適当な英語入れると絞り込みできる
- [x] 候補に一致しなければ「一致しない」とリストに表示
- [x] 候補を選択すると検索フォームに選択したものを表示
