### PR TITLE
累計目標達成数の表示と、目標のステータスによって、ラベルの色を変更する対応

### DIFF
--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -7,7 +7,9 @@
         </v-icon>
         {{ _isPC ? goal.title : '' }}
         <v-chip class="ma-2" color="chipBg">
-          <v-icon left color="challengingColor">mdi-fire</v-icon>
+          <v-icon small left :color="_getLabelColor(goal.label)"
+            >mdi-circle</v-icon
+          >
           {{ goal.label }}
         </v-chip>
         <v-btn icon @click="goalEditDialog = true">

--- a/client/components/organisms/profile/GoalList.vue
+++ b/client/components/organisms/profile/GoalList.vue
@@ -12,8 +12,10 @@
             <v-list-item-title>
               {{ goal.title
               }}<v-chip class="ma-2" color="chipBg">
-                <v-icon left color="challengingColor">mdi-fire</v-icon>
-                Challenging
+                <v-icon small left :color="_getLabelColor(goal.label)"
+                  >mdi-circle</v-icon
+                >
+                {{ goal.label }}
               </v-chip>
             </v-list-item-title>
           </v-list-item-content>

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -46,7 +46,9 @@
           <p class="mb-0" :class="_isPC && 'text-h6 font-weight-bold'">
             目標達成数
           </p>
-          <p class="text-subtitle-1">99</p>
+          <p class="text-subtitle-1">
+            {{ goals.filter((g) => g.label === 'ACHIEVEMENT').length }}
+          </p>
         </div>
       </div>
       <div class="d-flex">
@@ -93,7 +95,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { goalStore, groupStore } from '@/store'
-import { CommitsSummary, GroupSerializer } from '@/openapi'
+import { CommitsSummary, GroupSerializer, GoalSerializer } from '@/openapi'
 import ProfileEditDialog from '@/components/organisms/profile/ProfileEditDialog.vue'
 
 export default Vue.extend({
@@ -111,6 +113,9 @@ export default Vue.extend({
     },
     groups(): GroupSerializer[] {
       return groupStore.groupsGetter
+    },
+    goals(): GoalSerializer[] {
+      return goalStore.goalsGetter
     }
   },
   methods: {

--- a/client/plugins/mixins/goal.ts
+++ b/client/plugins/mixins/goal.ts
@@ -9,6 +9,24 @@ const Goal = {
         _goal(): GoalSerializer | null {
           return goalStore.goalGetter
         }
+      },
+      methods: {
+        _getLabelColor(label: string) {
+          switch (label) {
+            case 'CHALLENGING': {
+              return 'orange'
+            }
+            case 'ACHIEVEMENT': {
+              return 'green'
+            }
+            case 'GIVEUP': {
+              return 'grey'
+            }
+            default: {
+              return 'grey'
+            }
+          }
+        }
       }
     })
   }

--- a/client/vuetype.d.ts
+++ b/client/vuetype.d.ts
@@ -10,6 +10,7 @@ declare module 'vue/types/vue' {
     _isSP: boolean
     _isPC: boolean
     _goal: GoalSerializer | null
+    _getLabelColor: (label: string) => string
     _startLoading: () => void
     _finishLoading: () => void
     _notifyyyy: (


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/vEbbj07a

## :memo: 概要
- 累計目標達成数の表示
  - 累計目標達成数を取得するためのAPIルートは必要なかった。なぜなら、プロフィールページではすでに目標一覧を取得できており、ステータスが達成になっているものだけ、filter関数を抽出し、数をカウントすれば良いからである
  - また、目標を100件単位で登録することは考えにくく、パフォーマンスの観点からも後まわしで良さそうであります
<img width="252" alt="スクリーンショット 2020-07-23 16 18 57" src="https://user-images.githubusercontent.com/35862303/88260883-37ea0880-cd00-11ea-9f72-e6e1655b1e02.png">

- プロフィールページの目標のステータスラベルの色を、適用されるように
<img width="352" alt="スクリーンショット 2020-07-23 16 13 48" src="https://user-images.githubusercontent.com/35862303/88260851-2a348300-cd00-11ea-976d-83601b818613.png">
- 目標詳細ページのヘッダー部分のステータスラベルの色を適用されるように
<img width="335" alt="スクリーンショット 2020-07-23 16 13 52" src="https://user-images.githubusercontent.com/35862303/88260858-2bfe4680-cd00-11ea-9901-c55aa8834d18.png">


## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] プロフィールページにて、累計目標達成数が表示されていること
- [ ] プロフィールページの目標のステータスラベルの色が適用されていること
<img width="352" alt="スクリーンショット 2020-07-23 16 13 48" src="https://user-images.githubusercontent.com/35862303/88260851-2a348300-cd00-11ea-976d-83601b818613.png">
- [ ] 目標詳細ページのヘッダー部分のステータスラベルの色を適用されていること
<img width="335" alt="スクリーンショット 2020-07-23 16 13 52" src="https://user-images.githubusercontent.com/35862303/88260858-2bfe4680-cd00-11ea-9901-c55aa8834d18.png">
