### PR TITLE
グループタイムラインに日付表示を追加

### DIFF
--- a/client/components/organisms/groups/_id/TimelineCommitCreated.vue
+++ b/client/components/organisms/groups/_id/TimelineCommitCreated.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-timeline-item right class="mainText--text mb-12">
+  <v-timeline-item right class="mainText--text mb-12 pr-7">
     <template v-slot:icon>
       <v-avatar>
         <v-img

--- a/client/components/organisms/groups/_id/TimelineGoalStatusUpdate.vue
+++ b/client/components/organisms/groups/_id/TimelineGoalStatusUpdate.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-timeline-item :right="true" class="mainText--text mb-12">
+  <v-timeline-item :right="true" class="mainText--text mb-12 pr-7">
     <template v-slot:icon>
       <v-avatar>
         <v-img

--- a/client/components/organisms/groups/_id/Timelines.vue
+++ b/client/components/organisms/groups/_id/Timelines.vue
@@ -1,8 +1,24 @@
 <template>
   <v-row v-if="group" justify="start">
-    <v-col cols="12" md="10">
+    <v-col cols="12">
       <v-timeline align-top dense>
         <template v-for="(timeline, index) in timelines">
+          <div
+            v-if="
+              index === 0 ||
+                !isSameDay(
+                  new Date(timeline.createdAt),
+                  new Date(timelines[index - 1].createdAt)
+                )
+            "
+            :key="`${index}-chip`"
+            class="d-flex justify-center"
+          >
+            <v-chip class="mx-auto">
+              {{ timeline.createdAt | createdAtToDate }}
+              <v-icon right>mdi-chevron-down</v-icon>
+            </v-chip>
+          </div>
           <TimelineCommitCreated
             v-if="timeline.type === 'COMMIT_CREATED'"
             :key="index"
@@ -23,6 +39,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { isSameDay } from 'date-fns'
 import { groupStore } from '@/store'
 import { TimelineSerializer, GroupSerializer } from '@/openapi'
 import TimelineGoalStatusUpdate from '@/components/organisms/groups/_id/TimelineGoalStatusUpdate.vue'
@@ -32,6 +49,11 @@ export default Vue.extend({
   components: {
     TimelineGoalStatusUpdate,
     TimelineCommitCreated
+  },
+  data() {
+    return {
+      isSameDay
+    }
   },
   computed: {
     group(): GroupSerializer | null {

--- a/client/components/organisms/profile/UserInfo.vue
+++ b/client/components/organisms/profile/UserInfo.vue
@@ -66,13 +66,14 @@
     <v-divider v-show="_isPC" class="my-7"></v-divider>
     <!-- PCのみ（スマホの場合は、サイドバーで見れるからかな） -->
     <v-list-item-group v-show="_isPC" v-if="groups.length" color="primary">
-      <v-subheader>グループ</v-subheader>
+      <v-subheader class="px-0">グループ</v-subheader>
       <v-list-item
         v-for="(group, index) in groups"
         :key="index"
+        class="pa-0"
         :to="`/groups/${group.id}`"
       >
-        <v-list-item-avatar>
+        <v-list-item-avatar class="px-0 mx-0">
           <v-icon color="indigo">mdi-account-group</v-icon>
         </v-list-item-avatar>
         <v-list-item-content>
@@ -81,8 +82,15 @@
           </v-list-item-title>
         </v-list-item-content>
         <v-list-item-action>
-          <v-badge color="error" content="6">
+          <v-badge
+            v-if="isSameDay(new Date(), new Date(group.lastTimelinePostedAt))"
+            color="error"
+            content="6"
+          >
             {{ group.lastTimelinePostedAt | createdAtToHHmm }}
+          </v-badge>
+          <v-badge v-else color="error" content="6">
+            {{ group.lastTimelinePostedAt | createdAtToDate }}
           </v-badge>
         </v-list-item-action>
       </v-list-item>
@@ -94,6 +102,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { isSameDay } from 'date-fns'
 import { goalStore, groupStore } from '@/store'
 import { CommitsSummary, GroupSerializer, GoalSerializer } from '@/openapi'
 import ProfileEditDialog from '@/components/organisms/profile/ProfileEditDialog.vue'
@@ -104,7 +113,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      profileEditDialog: false
+      profileEditDialog: false,
+      isSameDay
     }
   },
   computed: {

--- a/client/pages/groups/_id/index.vue
+++ b/client/pages/groups/_id/index.vue
@@ -4,7 +4,7 @@
       <v-card>
         <TimelineHeader />
         <GroupAssociation class="groupAssociationBg" />
-        <Timeline />
+        <Timelines />
       </v-card>
     </v-col>
   </v-row>
@@ -13,13 +13,13 @@
 import Vue from 'vue'
 import { groupStore, goalStore } from '@/store'
 import TimelineHeader from '@/components/organisms/groups/_id/TimelineHeader.vue'
-import Timeline from '@/components/organisms/groups/_id/Timeline.vue'
+import Timelines from '@/components/organisms/groups/_id/Timelines.vue'
 import GroupAssociation from '@/components/organisms/groups/_id/GroupAssociation.vue'
 
 export default Vue.extend({
   middleware: 'authenticated',
   components: {
-    Timeline,
+    Timelines,
     TimelineHeader,
     GroupAssociation
   },

--- a/client/plugins/filter.ts
+++ b/client/plugins/filter.ts
@@ -29,3 +29,10 @@ Vue.filter('toJPYM', function(value: string) {
 Vue.filter('createdAtToHHmm', function(value: string) {
   return format(new Date(value), 'HH:mm')
 })
+
+/**
+ * '2020-07-23T03:35:57.953Z' → '2020/07/23' に変換する
+ */
+Vue.filter('createdAtToDate', function(value: string) {
+  return format(new Date(value), 'yyyy/MM/dd')
+})


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/3u4xEDPM

## :memo: 概要
- グループタイムラインに日付表示を追加
<img width="647" alt="スクリーンショット 2020-07-23 22 20 54" src="https://user-images.githubusercontent.com/35862303/88291168-c8414100-cd32-11ea-8fc4-e79d8512c52a.png">

- 最終更新日時が本日ではない場合、時刻ではなく、日付を表示
<img width="212" alt="スクリーンショット 2020-07-23 22 29 59" src="https://user-images.githubusercontent.com/35862303/88292026-0d19a780-cd34-11ea-844c-d0e9bff3ae5f.png">

- プロフィール画面でのグループリストの幅を少し広げる

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] タイムラインの投稿の日付が変わった時に、日付のラベルが表示されていること
- [ ] プロフィールページのグループリストにおいて、最終更新日時が本日ではない場合、時刻ではなく、日付を表示されていること
- [ ] プロフィール画面でのグループリストの幅を少し広がっていること
