### PR TITLE
参加しているグループがない時にエラーになる問題を修正

### DIFF
--- a/api/src/search/searches.service.ts
+++ b/api/src/search/searches.service.ts
@@ -39,6 +39,8 @@ export class SearchesService {
       .where('goal.user_id IN (:users)', {
         users: uniqueUsers.map(uu => uu.id),
       })
+      .andWhere('goal.isPublic = true')
+      .orWhere('goal.user_id = :userId', { userId: user.id })
       .leftJoinAndSelect('goal.user', 'user') // ユーザーネームも一応欲しいため
       .getMany();
 

--- a/api/src/search/searches.service.ts
+++ b/api/src/search/searches.service.ts
@@ -25,9 +25,10 @@ export class SearchesService {
     const groups = await this.groupRepository.getGroupsUserMemberOf(user);
 
     // 同じグループのユーザーを取得
-    const allUsers: UserEntity[] = [].concat(
-      ...groups.map(group => group.users),
-    );
+    const allUsers: UserEntity[] =
+      groups.length !== 0
+        ? [].concat(...groups.map(group => group.users))
+        : [user];
     const uniqueUsers = allUsers.filter(
       (filteringUser, index) =>
         allUsers.findIndex(u => u.id === filteringUser.id) === index,


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/QENpKnBy

## :memo: 概要
- 参加しているグループがない時に、navbarの検索のAPIでエラーが起きる問題を修正
- ついでに、他人のプライベート目標は取得出来ないようにする

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 新規作成ユーザーなどの、なんのグループにも所属していないユーザーでログインしたとき、navbarの検索に自分のデータが表示されていること
<img width="421" alt="スクリーンショット 2020-07-23 23 04 22" src="https://user-images.githubusercontent.com/35862303/88295792-da25e280-cd38-11ea-9a2e-3bb3da462c99.png">

