### PR TITLE
他人の目標詳細のところで、誰の目標かをわかりやすく表示

### DIFF
--- a/api/src/goals/goals.service.ts
+++ b/api/src/goals/goals.service.ts
@@ -111,6 +111,7 @@ export class GoalsService {
     user: UserEntity,
   ): Promise<GoalEntity> {
     const goal = await this.goalRepository.findOne({
+      relations: ['user'],
       where: { id: goalId, userId: user.id },
     });
     if (!goal) {

--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -5,7 +5,7 @@
         <v-icon v-show="_isPC" large>
           {{ !!goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
         </v-icon>
-        {{ _isPC ? goal.title : '' }}
+        {{ _isPC ? `${goal.user.username}/${goal.title}` : '' }}
         <v-chip class="ma-2" color="chipBg">
           <v-icon small left :color="_getLabelColor(goal.label)"
             >mdi-circle</v-icon

--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -1,11 +1,15 @@
 <template>
   <div>
     <div class="d-flex justify-space-between align-center pt-5">
-      <p class="text-h4 font-weight-bold text-no-wrap">
-        <v-icon v-show="_isPC" large>
-          {{ !!goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
-        </v-icon>
-        {{ _isPC ? `${goal.user.username}/${goal.title}` : '' }}
+      <div class="d-flex justify-start align-center">
+        <div v-if="_isPC">
+          <p class="ml-3 mb-0">{{ goal.user.username }}</p>
+          <p class="text-h4 font-weight-bold text-no-wrap">
+            <v-icon v-show="_isPC" large>
+              {{ !!goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }} </v-icon
+            >{{ _isPC && goal.title }}
+          </p>
+        </div>
         <v-chip class="ma-2" color="chipBg">
           <v-icon small left :color="_getLabelColor(goal.label)"
             >mdi-circle</v-icon
@@ -16,7 +20,7 @@
           <v-icon midium>mdi-cog</v-icon>
         </v-btn>
         <GoalEditDialog v-model="goalEditDialog" :goal="goal" />
-      </p>
+      </div>
       <div class="d-flex justify-end">
         <p class="mr-4">
           <v-icon color="primary">mdi-timer-outline</v-icon
@@ -26,7 +30,10 @@
       </div>
     </div>
     <v-divider class="mb-4"></v-divider>
-    <p v-show="_isSP" class="text-h4 primary--text font-weight-bold">
+    <p
+      v-show="_isSP && goal.description"
+      class="text-h4 primary--text font-weight-bold"
+    >
       目標について
     </p>
     <p class="text-subtitle-1">{{ goal.description }}</p>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -82,10 +82,15 @@
       <v-container v-if="isGoalDetailPage && _isSP && _goal" fluid>
         <v-row justify="center" class="mainText--text">
           <v-toolbar-title>
-            <v-icon large>
-              {{ _goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
-            </v-icon>
-            {{ _goal.title ? `${_goal.user.username}/${_goal.title}` : '' }}
+            <p class="mb-n1 pb-0 mt-3 text-caption text-center">
+              {{ _goal.user.username }}
+            </p>
+            <p class="mt-0 text-h6 font-weight-bold">
+              <v-icon>
+                {{ _goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
+              </v-icon>
+              {{ _goal.title || '' }}
+            </p>
           </v-toolbar-title>
         </v-row>
       </v-container>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -85,7 +85,7 @@
             <v-icon large>
               {{ _goal.isPublic ? 'mdi-earth' : 'mdi-lock-outline' }}
             </v-icon>
-            {{ _goal.title || '' }}
+            {{ _goal.title ? `${_goal.user.username}/${_goal.title}` : '' }}
           </v-toolbar-title>
         </v-row>
       </v-container>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/dlFgkOZY

## :memo: 概要
他人の目標詳細のところで、誰の目標かをわかりやすく表示
UXの意見を待ちます:pray:
<img width="637" alt="スクリーンショット 2020-07-25 12 36 00" src="https://user-images.githubusercontent.com/35862303/88447961-c4690800-ce73-11ea-83b8-3055ae678f64.png">
<img width="484" alt="スクリーンショット 2020-07-25 12 36 21" src="https://user-images.githubusercontent.com/35862303/88447963-c763f880-ce73-11ea-8558-d7677dda24e0.png">



## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 目標名の上に、ユーザー名が小さく表示されていること
