### PR TITLE
目標詳細ページにおける、学習記録モーダルの挙動の不具合とコンポーネント構造の修正

### DIFF
--- a/client/components/organisms/goals/index/CommitsTable.vue
+++ b/client/components/organisms/goals/index/CommitsTable.vue
@@ -35,7 +35,7 @@
                 <v-btn v-if="Iam.id != goal.userId" icon color="satisfyIcon">
                   <v-icon>mdi-emoticon-outline</v-icon>
                 </v-btn>
-                <v-btn icon @click="openDeleteModal(commit.id)">
+                <v-btn icon @click="openDeleteModal(commit)">
                   <v-icon>mdi-delete-outline</v-icon>
                 </v-btn>
               </div>
@@ -54,60 +54,27 @@
         circle
       ></v-pagination>
     </div>
-    <v-dialog v-model="isDialogOpen" max-width="600px">
-      <CreateCommitDialog
-        :close-dialog="
-          () => {
-            this.$emit('close')
-          }
-        "
-        :init-display-condition="initDisplayCondition"
-      />
-    </v-dialog>
-    <v-dialog v-model="dialog" max-width="290">
-      <v-card>
-        <v-card-title class="headline">
-          学習記録を削除する
-        </v-card-title>
-
-        <v-card-text>
-          この学習記録を本当に削除しますか？削除後は元に戻すことはできません。
-        </v-card-text>
-
-        <v-card-actions>
-          <v-spacer></v-spacer>
-
-          <v-btn color="green darken-1" text @click="dialog = false">
-            キャンセル
-          </v-btn>
-
-          <v-btn color="error" text @click="deleteCommit">
-            削除する
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <DeleteCommitDialog
+      v-if="deleteCommit"
+      v-model="deleteCommitDialogOpen"
+      :commit="deleteCommit"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { format } from 'date-fns'
-import { goalStore } from '@/store'
 import { CommitSerializer, GoalSerializer } from '@/openapi'
-import CreateCommitDialog from '@/components/organisms/goals/index/CreateCommitDialog.vue'
+import DeleteCommitDialog from '@/components/organisms/goals/index/DeleteCommitDialog.vue'
 
 export default Vue.extend({
   components: {
-    CreateCommitDialog
+    DeleteCommitDialog
   },
   props: {
     commits: {
       type: Array as PropType<CommitSerializer[]>,
-      required: true
-    },
-    createCommitDialog: {
-      type: Boolean,
       required: true
     },
     goal: {
@@ -122,8 +89,8 @@ export default Vue.extend({
       },
       page: 1,
       pageSize: 10,
-      dialog: false,
-      deleteCommitId: null as number | null
+      deleteCommitDialogOpen: false,
+      deleteCommit: null as CommitSerializer | null
     }
   },
   computed: {
@@ -145,14 +112,6 @@ export default Vue.extend({
     },
     paginationLength(): number {
       return Math.ceil(this.commits.length / this.pageSize)
-    },
-    isDialogOpen: {
-      get() {
-        return this.createCommitDialog
-      },
-      set(isOpen) {
-        return isOpen
-      }
     }
   },
   watch: {
@@ -170,36 +129,12 @@ export default Vue.extend({
     ): Array<any> {
       return array.slice((pageNumber - 1) * pageSize, pageNumber * pageSize)
     },
+    openDeleteModal(commit: CommitSerializer) {
+      this.deleteCommitDialogOpen = true
+      this.deleteCommit = commit
+    },
     initDisplayCondition() {
       this.page = 1
-    },
-    async deleteCommit() {
-      if (!this.deleteCommitId) return
-      this._startLoading()
-      const { error, messages } = await goalStore.deleteCommit(
-        this.deleteCommitId
-      )
-      this._finishLoading()
-      if (!error) {
-        this._notifyyyy([
-          {
-            message: '学習記録を削除しました',
-            type: 'success'
-          }
-        ])
-      } else if (error && messages) {
-        this._notifyyyy(
-          messages.map((message: string) => ({
-            message,
-            type: 'error'
-          }))
-        )
-      }
-      this.dialog = false
-    },
-    openDeleteModal(commitId: number) {
-      this.dialog = true
-      this.deleteCommitId = commitId
     }
   }
 })

--- a/client/components/organisms/goals/index/CreateCommitDialog.vue
+++ b/client/components/organisms/goals/index/CreateCommitDialog.vue
@@ -1,85 +1,87 @@
 <template>
-  <v-card>
-    <v-card-title>
-      <span class="headline">
-        <v-icon color="primary">mdi-pencil</v-icon>
-        学習を記録する
-      </span>
-    </v-card-title>
-    <v-divider></v-divider>
-    <v-card-text>
-      <v-form v-model="valid">
-        <v-container>
-          <v-row>
-            <v-col cols="12">
-              <v-text-field
-                v-model="form.title"
-                label="学習名"
-                :rules="rules.title"
-                outlined
-                required
-                max-width="100"
-              >
-              </v-text-field>
-            </v-col>
-            <v-col cols="12" sm="6" md="4">
-              <v-menu
-                ref="menu"
-                v-model="timePicker"
-                :close-on-content-click="false"
-                :nudge-right="40"
-                :return-value.sync="form.time"
-                transition="scale-transition"
-                offset-y
-                max-width="290px"
-                min-width="290px"
-              >
-                <template v-slot:activator="{ on, attrs }">
-                  <v-text-field
+  <v-dialog v-model="dialog" max-width="600px">
+    <v-card>
+      <v-card-title>
+        <span class="headline">
+          <v-icon color="primary">mdi-pencil</v-icon>
+          学習を記録する
+        </span>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text>
+        <v-form v-model="valid">
+          <v-container>
+            <v-row>
+              <v-col cols="12">
+                <v-text-field
+                  v-model="form.title"
+                  label="学習名"
+                  :rules="rules.title"
+                  outlined
+                  required
+                  max-width="100"
+                >
+                </v-text-field>
+              </v-col>
+              <v-col cols="12" sm="6" md="4">
+                <v-menu
+                  ref="menu"
+                  v-model="timePicker"
+                  :close-on-content-click="false"
+                  :nudge-right="40"
+                  :return-value.sync="form.time"
+                  transition="scale-transition"
+                  offset-y
+                  max-width="290px"
+                  min-width="290px"
+                >
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-text-field
+                      v-model="form.time"
+                      label="学習時間"
+                      append-icon="mdi-timer-outline"
+                      :rules="rules.time"
+                      readonly
+                      v-bind="attrs"
+                      outlined
+                      v-on="on"
+                    ></v-text-field>
+                  </template>
+                  <v-time-picker
+                    v-if="timePicker"
                     v-model="form.time"
-                    label="学習時間"
-                    append-icon="mdi-timer-outline"
-                    :rules="rules.time"
-                    readonly
-                    v-bind="attrs"
-                    outlined
-                    v-on="on"
-                  ></v-text-field>
-                </template>
-                <v-time-picker
-                  v-if="timePicker"
-                  v-model="form.time"
-                  full-width
-                  format="24hr"
-                  @click:minute="$refs.menu.save(form.time)"
-                ></v-time-picker>
-              </v-menu>
-            </v-col>
-            <v-col cols="12">
-              <v-textarea
-                v-model="form.description"
-                label="学習内容"
-                outlined
-              ></v-textarea>
-            </v-col>
-            <v-col>
-              <v-divider></v-divider>
-            </v-col>
-            <v-col cols="12">
-              <v-btn
-                large
-                color="primary"
-                :disabled="!valid"
-                :block="_isSP"
-                @click="onSubmit"
-                >学習を記録する</v-btn
-              >
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-form>
-    </v-card-text>
-  </v-card>
+                    full-width
+                    format="24hr"
+                    @click:minute="$refs.menu.save(form.time)"
+                  ></v-time-picker>
+                </v-menu>
+              </v-col>
+              <v-col cols="12">
+                <v-textarea
+                  v-model="form.description"
+                  label="学習内容"
+                  outlined
+                ></v-textarea>
+              </v-col>
+              <v-col>
+                <v-divider></v-divider>
+              </v-col>
+              <v-col cols="12">
+                <v-btn
+                  large
+                  color="primary"
+                  :disabled="!valid"
+                  :block="_isSP"
+                  @click="onSubmit"
+                  >学習を記録する</v-btn
+                >
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts">
@@ -89,8 +91,8 @@ import { CreateCommitDto } from '@/openapi'
 
 export default Vue.extend({
   props: {
-    closeDialog: {
-      type: Function,
+    value: {
+      type: Boolean,
       required: true
     },
     initDisplayCondition: {
@@ -121,6 +123,16 @@ export default Vue.extend({
       timePicker: false
     }
   },
+  computed: {
+    dialog: {
+      get(): boolean {
+        return this.value
+      },
+      set(dialog: boolean) {
+        this.$emit('input', dialog)
+      }
+    }
+  },
   methods: {
     async onSubmit() {
       const createCommitDto: CreateCommitDto = {
@@ -142,7 +154,7 @@ export default Vue.extend({
           }))
         )
       } else {
-        this.closeDialog()
+        this.dialog = false
         this.form.title = ''
         this.form.description = ''
         this.form.time = '00:00'

--- a/client/components/organisms/goals/index/DeleteCommitDialog.vue
+++ b/client/components/organisms/goals/index/DeleteCommitDialog.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-dialog v-model="dialog" max-width="290">
+    <v-card>
+      <v-card-title class="headline">
+        学習記録を削除する
+      </v-card-title>
+
+      <v-card-text>
+        この学習記録を本当に削除しますか？削除後は元に戻すことはできません。
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+
+        <v-btn color="green darken-1" text @click="dialog = false">
+          キャンセル
+        </v-btn>
+
+        <v-btn color="error" text @click="deleteCommit">
+          削除する
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import { CommitSerializer } from '@/openapi'
+import { goalStore } from '@/store'
+
+export default Vue.extend({
+  props: {
+    value: {
+      type: Boolean,
+      required: true
+    },
+    commit: {
+      type: Object as PropType<CommitSerializer>,
+      required: true
+    }
+  },
+  computed: {
+    dialog: {
+      get(): boolean {
+        return this.value
+      },
+      set(dialog: boolean) {
+        this.$emit('input', dialog)
+      }
+    }
+  },
+  methods: {
+    async deleteCommit() {
+      this._startLoading()
+      const { error, messages } = await goalStore.deleteCommit(this.commit.id)
+      this._finishLoading()
+      if (!error) {
+        this._notifyyyy([
+          {
+            message: '学習記録を削除しました',
+            type: 'success'
+          }
+        ])
+      } else if (error && messages) {
+        this._notifyyyy(
+          messages.map((message: string) => ({
+            message,
+            type: 'error'
+          }))
+        )
+      }
+      this.dialog = false
+    }
+  }
+})
+</script>

--- a/client/pages/goals/_id/index.vue
+++ b/client/pages/goals/_id/index.vue
@@ -10,12 +10,17 @@
       </v-row>
       <CommitsTable
         v-if="goal"
+        ref="commitsTable"
         :commits="commits"
         :goal="goal"
         :create-commit-dialog="createCommitDialog"
         @close="createCommitDialog = false"
       />
     </v-col>
+    <CreateCommitDialog
+      v-model="createCommitDialog"
+      :init-display-condition="initDisplayCondition"
+    />
   </v-row>
 </template>
 
@@ -25,18 +30,18 @@ import { goalStore } from '@/store'
 import GoalDetailHeader from '@/components/organisms/goals/index/GoalDetailHeader.vue'
 import CommitsTable from '@/components/organisms/goals/index/CommitsTable.vue'
 import { GoalSerializer, CommitSerializer } from '@/openapi'
+import CreateCommitDialog from '@/components/organisms/goals/index/CreateCommitDialog.vue'
 
 export default Vue.extend({
   middleware: 'authenticated',
   components: {
     CommitsTable,
-    GoalDetailHeader
+    GoalDetailHeader,
+    CreateCommitDialog
   },
   data() {
     return {
-      createCommitDialog: false,
-      page: 1,
-      pageSize: 10
+      createCommitDialog: false
     }
   },
   computed: {
@@ -82,6 +87,12 @@ export default Vue.extend({
       this.$router.push('/profile')
     }
     this._finishLoading()
+  },
+  methods: {
+    initDisplayCondition() {
+      const commitsTable = this.$refs.commitsTable as any
+      commitsTable.initDisplayCondition()
+    }
   }
 })
 </script>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/VBvxT9CM

## :memo: 概要
- 目標詳細画面での学習記録ボタン、開いて次に、モーダルの外側をクリックして閉じると、開けなくなる問題を修正しました
- 削除モーダルを適切にコンポーネントに分割しました

## :stuck_out_tongue: やってないこと
タイムラインに紐づいている学習は削除出来ない問題があった（タイムラインごと削除すべきか、それとも削除出来ませんとするのか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 目標詳細画面での学習記録ボタン、開いて次に、モーダルの外側をクリックして閉じても、再度ボタンを押して開けること
- [ ] 投稿したあと、１ページ目に戻ること
- [ ] 学習記録の削除モーダルが機能していること 
