### PR TITLE
目標の検索結果ページの左の部分に、ステータスを選べる欄を作成する

### DIFF
--- a/api/src/search/searches.service.ts
+++ b/api/src/search/searches.service.ts
@@ -65,7 +65,11 @@ export class SearchesService {
       newGoal.id = index;
       newGoal.title = `目標${index}`;
       newGoal.description = 'fugafuga';
-      newGoal.label = GoalLabelEnum.CHALLENGING;
+      newGoal.label = [
+        GoalLabelEnum.CHALLENGING,
+        GoalLabelEnum.ACHIEVEMENT,
+        GoalLabelEnum.GIVE_UP,
+      ][index % 3];
       newGoal.isPublic = false;
       newGoal.userId = 1;
       newGoal.user = user;

--- a/client/components/organisms/search/SearchGoalList.vue
+++ b/client/components/organisms/search/SearchGoalList.vue
@@ -1,23 +1,25 @@
 <template>
   <div>
     <v-list v-for="(goal, index) in goals" :key="index" class="elevation-1">
-      <v-list-item class="ml-12">
+      <v-list-item class="ml-12" :to="`/goals/${goal.id}`">
         <v-list-item-content>
           <v-list-item-title class="mainText--text">{{
             goal.user.username
           }}</v-list-item-title>
-          <v-list-item-subtitle class="mt-2">
+          <v-list-item-subtitle>
             <v-icon>mdi-earth</v-icon
             ><span class="font-weight-bold mainText--text">{{
               goal.title
             }}</span
             ><v-chip class="ma-2" color="chipBg">
-              <v-icon left color="challengingColor">mdi-fire</v-icon>
+              <v-icon small left :color="_getLabelColor(goal.label)"
+                >mdi-circle</v-icon
+              >
               {{ goal.label }}
             </v-chip>
           </v-list-item-subtitle>
           <v-list-item-subtitle class="mainText--text ml-3">
-            {{ goal.description }}
+            {{ goal.description || '' }}
           </v-list-item-subtitle>
           <v-list-item-subtitle class="mt-2 ml-3">
             <div>
@@ -36,13 +38,14 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-import { searchStore } from '@/store'
+import Vue, { PropType } from 'vue'
 import { GoalSerializer } from '@/openapi'
+
 export default Vue.extend({
-  computed: {
-    goals(): GoalSerializer[] {
-      return searchStore.goalsGetter
+  props: {
+    goals: {
+      type: Array as PropType<GoalSerializer[]>,
+      required: true
     }
   }
 })

--- a/client/components/organisms/search/SearchUserList.vue
+++ b/client/components/organisms/search/SearchUserList.vue
@@ -26,13 +26,14 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-import { searchStore } from '@/store'
+import Vue, { PropType } from 'vue'
 import { UserSerializer } from '@/openapi'
+
 export default Vue.extend({
-  computed: {
-    users(): UserSerializer[] {
-      return searchStore.usersGetter
+  props: {
+    users: {
+      type: Array as PropType<UserSerializer[]>,
+      required: true
     }
   }
 })

--- a/client/pages/search/index.vue
+++ b/client/pages/search/index.vue
@@ -36,11 +36,28 @@
                   >mdi-flag</v-icon
                 >目標
               </v-btn>
+              <v-divider></v-divider>
+
+              <v-list v-if="goalTabSelected" rounded>
+                <v-subheader>Labels</v-subheader>
+                <v-list-item-group v-model="selectedLabelIndex" color="primary">
+                  <v-list-item v-for="(label, index) in labels" :key="index">
+                    <v-list-item-icon class="mr-0">
+                      <v-icon small :color="label.color">mdi-circle</v-icon>
+                    </v-list-item-icon>
+                    <v-list-item-content>
+                      <v-list-item-title
+                        v-text="label.title"
+                      ></v-list-item-title>
+                    </v-list-item-content>
+                  </v-list-item>
+                </v-list-item-group>
+              </v-list>
             </v-col>
             <!-- カラム2 -->
             <v-col cols="10">
               <SearchUserList v-if="userTabSelected" :users="users" />
-              <SearchGoalList v-if="goalTabSelected" :goals="goals" />
+              <SearchGoalList v-if="goalTabSelected" :goals="filteredGoals" />
             </v-col>
           </v-row>
         </v-card>
@@ -52,7 +69,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import { searchStore } from '@/store'
-import { UserSerializer, GoalSerializer } from '@/openapi'
+import {
+  UserSerializer,
+  GoalSerializer,
+  GoalSerializerLabelEnum
+} from '@/openapi'
 import SearchUserList from '@/components/organisms/search/SearchUserList.vue'
 import SearchGoalList from '@/components/organisms/search/SearchGoalList.vue'
 
@@ -67,7 +88,13 @@ export default Vue.extend({
   data() {
     return {
       tab: 'user' as TabType,
-      keyword: '' as string
+      keyword: '' as string,
+      selectedLabelIndex: undefined,
+      labels: [
+        { title: GoalSerializerLabelEnum.CHALLENGING, color: 'orange' },
+        { title: GoalSerializerLabelEnum.ACHIEVEMENT, color: 'green' },
+        { title: GoalSerializerLabelEnum.GIVEUP, color: 'grey' }
+      ]
     }
   },
   computed: {
@@ -82,6 +109,13 @@ export default Vue.extend({
     },
     goals(): GoalSerializer[] {
       return searchStore.goalsGetter
+    },
+    filteredGoals(): GoalSerializer[] {
+      if (typeof this.selectedLabelIndex === 'undefined') {
+        return this.goals
+      }
+      const filterLabel = this.labels[this.selectedLabelIndex!].title
+      return this.goals.filter((g) => g.label === filterLabel)
     }
   },
   watch: {

--- a/client/pages/search/index.vue
+++ b/client/pages/search/index.vue
@@ -39,8 +39,8 @@
             </v-col>
             <!-- カラム2 -->
             <v-col cols="10">
-              <SearchUserList v-if="userTabSelected" />
-              <SearchGoalList v-if="goalTabSelected" />
+              <SearchUserList v-if="userTabSelected" :users="users" />
+              <SearchGoalList v-if="goalTabSelected" :goals="goals" />
             </v-col>
           </v-row>
         </v-card>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/6RJ8Cuvb

## :memo: 概要
- 検索結果画面での、ラベルによる絞り込み機能追加
<img width="526" alt="スクリーンショット 2020-07-26 14 51 09" src="https://user-images.githubusercontent.com/35862303/88472595-74f80a00-cf4f-11ea-8d66-a3fbb82c2f08.png">

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 検索結果画面における、目標のラベルによる絞り込みができること
- [ ] 検索結果リストのラベルのところが、ラベルによって色が変わっていること
  - challengingがorange, achievementがgreen, giveupがgrey
