### PR TITLE
グループのタイムラインヘッダー部分のスマホ対応

### DIFF
--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -1,39 +1,45 @@
 <template>
-  <div v-if="group" class="justify-space-between cardGreyBg ma-0 pt-2 pb-2">
-    <div v-show="_isPC" class="col-12 ml-3">
-      <v-icon large left color="primary" class="d-inline-flex">
-        mdi-account-group
-      </v-icon>
-      <h2 class="d-inline-flex">{{ group.name }}</h2>
-    </div>
-    <div v-show="_isPC" class="mr-3">
-      <div class="d-inline-flex">
-        <v-text-field
-          class="ml-6 mr-3 d-inline-flex"
-          hide-details
-          placeholder="検索"
-          append-icon="mdi-magnify"
-          solo
-          dense
-        ></v-text-field>
-        <v-avatar
-          v-for="user in group.users"
-          :key="user.id"
-          color="indigo"
-          size="36"
-          class="ma-0 d-inline-flex"
-        >
-          <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
-          <svg
-            v-else
-            viewBox="0 0 640 640"
-            v-html="jdenticonSvg(user.email)"
-          ></svg>
-        </v-avatar>
-        <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>
-        <v-btn color="white"><v-icon>mdi-cog</v-icon>設定</v-btn>
+  <div v-if="group" class="">
+    <!-- PC用の表示 -->
+    <div v-show="_isPC">
+      <div class="d-flex justify-space-between cardGreyBg ma-0 pt-2 pb-2">
+        <div class="d-flex ml-3">
+          <v-icon large left color="primary">
+            mdi-account-group
+          </v-icon>
+          <h2>{{ group.name }}</h2>
+        </div>
+        <div class="d-flex mr-3">
+          <div class="d-flex">
+            <v-text-field
+              class="ml-6 mr-3"
+              hide-details
+              placeholder="検索"
+              append-icon="mdi-magnify"
+              solo
+              dense
+            ></v-text-field>
+            <v-avatar
+              v-for="user in group.users"
+              :key="user.id"
+              color="indigo"
+              size="36"
+              class="ma-0"
+            >
+              <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
+              <svg
+                v-else
+                viewBox="0 0 640 640"
+                v-html="jdenticonSvg(user.email)"
+              ></svg>
+            </v-avatar>
+            <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>
+            <v-btn color="white"><v-icon>mdi-cog</v-icon>設定</v-btn>
+          </div>
+        </div>
       </div>
     </div>
+    <!-- スマホ用の表示 -->
     <div v-show="_isSP" class="col-sm-12">
       <div class="col-12 d-flex">
         <v-icon left color="primary" class="d-flex">

--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="group" class="">
+  <div v-if="group">
     <!-- PC用の表示 -->
     <div v-show="_isPC">
       <div class="d-flex justify-space-between cardGreyBg ma-0 pt-2 pb-2">

--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -1,39 +1,76 @@
 <template>
-  <div
-    v-if="group"
-    class="d-flex justify-space-between cardGreyBg ma-0 pt-2 pb-2"
-  >
-    <div class="d-flex ml-3">
-      <v-icon large left color="primary">
+  <div v-if="group" class="justify-space-between cardGreyBg ma-0 pt-2 pb-2">
+    <div v-show="_isPC" class="col-12 ml-3">
+      <v-icon large left color="primary" class="d-inline-flex">
         mdi-account-group
       </v-icon>
-      <h2>{{ group.name }}</h2>
+      <h2 class="d-inline-flex">{{ group.name }}</h2>
     </div>
-    <div class="d-flex mr-3">
-      <v-text-field
-        class="ml-6 mr-3"
-        hide-details
-        placeholder="検索"
-        append-icon="mdi-magnify"
-        solo
-        dense
-      ></v-text-field>
-      <v-avatar
-        v-for="user in group.users"
-        :key="user.id"
-        color="indigo"
-        size="36"
-        class="ma-0"
-      >
-        <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
-        <svg
-          v-else
-          viewBox="0 0 640 640"
-          v-html="jdenticonSvg(user.email)"
-        ></svg>
-      </v-avatar>
-      <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>
-      <v-btn color="white"><v-icon>mdi-cog</v-icon>設定</v-btn>
+    <div v-show="_isPC" class="mr-3">
+      <div class="d-inline-flex">
+        <v-text-field
+          class="ml-6 mr-3 d-inline-flex"
+          hide-details
+          placeholder="検索"
+          append-icon="mdi-magnify"
+          solo
+          dense
+        ></v-text-field>
+        <v-avatar
+          v-for="user in group.users"
+          :key="user.id"
+          color="indigo"
+          size="36"
+          class="ma-0 d-inline-flex"
+        >
+          <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
+          <svg
+            v-else
+            viewBox="0 0 640 640"
+            v-html="jdenticonSvg(user.email)"
+          ></svg>
+        </v-avatar>
+        <v-btn color="primary" class="ml-3 mr-3">招待</v-btn>
+        <v-btn color="white"><v-icon>mdi-cog</v-icon>設定</v-btn>
+      </div>
+    </div>
+    <div v-show="_isSP" class="col-sm-12">
+      <div class="col-12 d-flex">
+        <v-icon left color="primary" class="d-flex">
+          mdi-account-group
+        </v-icon>
+        <h2 class="d-flex">{{ group.name }}</h2>
+        <v-btn small class="d-flex ml-3" color="white">
+          <v-icon>mdi-cog</v-icon>設定
+        </v-btn>
+      </div>
+      <div class="col-12">
+        <v-avatar
+          v-for="user in group.users"
+          :key="user.id"
+          color="indigo"
+          size="36"
+          class="ma-0 d-inline-flex"
+        >
+          <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
+          <svg
+            v-else
+            viewBox="0 0 640 640"
+            v-html="jdenticonSvg(user.email)"
+          ></svg>
+        </v-avatar>
+        <v-btn small color="primary" class="ml-3 mr-3">招待</v-btn>
+      </div>
+      <div class="col-12">
+        <v-text-field
+          class=""
+          hide-details
+          placeholder="検索"
+          append-icon="mdi-magnify"
+          solo
+          dense
+        ></v-text-field>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/gD63ybl3

## :memo: 概要
(やった内容を書こう！)
スマホ画面時のグループヘッダーをzeplinに近くなるように変更
https://zpl.io/a8g7gj6
若干デザイン違うけど、横幅が狭く入り切らないと判断しますた

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] F12でスマホ画面にしてグループを見るとグループヘッダーがいい感じになってる
- [ ] PC画面でグループを見ても従来通りのグループヘッダーになってる
