### PR TITLE
検索結果のユーザーリストのところでアイコンが反映されていない

### DIFF
--- a/client/components/organisms/search/SearchUserList.vue
+++ b/client/components/organisms/search/SearchUserList.vue
@@ -3,7 +3,14 @@
     <v-list v-for="(user, index) in users" :key="index" class="elevation-1">
       <v-list-item :to="`/users/${user.id}`">
         <v-list-item-icon>
-          <v-avatar color="indigo"> </v-avatar>
+          <v-avatar color="indigo" size="36" class="ma-0">
+            <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
+            <svg
+              v-else
+              viewBox="0 0 640 640"
+              v-html="jdenticonSvg(user.email)"
+            ></svg>
+          </v-avatar>
         </v-list-item-icon>
         <v-list-item-content>
           <v-list-item-title>{{ user.username }}</v-list-item-title>


### PR DESCRIPTION
## :ticket: チケット
(trelloのチケットのリンクを貼りましょう)
https://trello.com/c/HP9r4J3T
## :memo: 概要
(やった内容を書こう！)
検索結果のユーザーリストのところでアイコンが反映されるようにした
## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] 検索したときのユーザ一覧でユーザアイコンが表示される