### PR TITLE
透過pngだと背景が青いアバターになる

### DIFF
--- a/client/components/organisms/groups/_id/TimelineCommitCreated.vue
+++ b/client/components/organisms/groups/_id/TimelineCommitCreated.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-timeline-item right class="mainText--text mb-12 pr-7">
+  <v-timeline-item
+    right
+    class="mainText--text mb-12 pr-7"
+    color="white lighten-2"
+  >
     <template v-slot:icon>
       <v-avatar>
         <v-img

--- a/client/components/organisms/groups/_id/TimelineGoalStatusUpdate.vue
+++ b/client/components/organisms/groups/_id/TimelineGoalStatusUpdate.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-timeline-item :right="true" class="mainText--text mb-12 pr-7">
+  <v-timeline-item
+    :right="true"
+    class="mainText--text mb-12 pr-7"
+    color="white lighten-2"
+  >
     <template v-slot:icon>
       <v-avatar>
         <v-img

--- a/client/components/organisms/groups/_id/TimelineHeader.vue
+++ b/client/components/organisms/groups/_id/TimelineHeader.vue
@@ -22,7 +22,7 @@
             <v-avatar
               v-for="user in group.users"
               :key="user.id"
-              color="indigo"
+              color="white"
               size="36"
               class="ma-0"
             >
@@ -54,7 +54,7 @@
         <v-avatar
           v-for="user in group.users"
           :key="user.id"
-          color="indigo"
+          color="white"
           size="36"
           class="ma-0 d-inline-flex"
         >

--- a/client/components/organisms/search/SearchUserList.vue
+++ b/client/components/organisms/search/SearchUserList.vue
@@ -3,7 +3,7 @@
     <v-list v-for="(user, index) in users" :key="index" class="elevation-1">
       <v-list-item :to="`/users/${user.id}`">
         <v-list-item-icon>
-          <v-avatar color="indigo" size="36" class="ma-0">
+          <v-avatar color="white" size="36" class="ma-0">
             <v-img v-if="user.avatarUrl" :src="user.avatarUrl" />
             <svg
               v-else


### PR DESCRIPTION
## :ticket: チケット
(trelloのチケットのリンクを貼りましょう)
https://trello.com/c/dHK4KxuW
## :memo: 概要
(やった内容を書こう！)
青から白に変更
## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] タイムラインページのユーザアイコンが透過画像の場合バックカラーが白
- [ ] 全体ユーザ検索も同様