### PR TITLE
他人の目標詳細画面において、歯車とプラスボタン、Deleteボタンは非表示にすべき

### DIFF
--- a/client/components/organisms/goals/index/CommitsTable.vue
+++ b/client/components/organisms/goals/index/CommitsTable.vue
@@ -35,7 +35,11 @@
                 <v-btn v-if="Iam.id != goal.userId" icon color="satisfyIcon">
                   <v-icon>mdi-emoticon-outline</v-icon>
                 </v-btn>
-                <v-btn icon @click="openDeleteModal(commit)">
+                <v-btn
+                  v-if="Iam.id == goal.userId"
+                  icon
+                  @click="openDeleteModal(commit)"
+                >
                   <v-icon>mdi-delete-outline</v-icon>
                 </v-btn>
               </div>

--- a/client/components/organisms/goals/index/CommitsTable.vue
+++ b/client/components/organisms/goals/index/CommitsTable.vue
@@ -32,14 +32,10 @@
                 </div>
               </div>
               <div class="d-flex align-self-center">
-                <v-btn v-if="Iam.id != goal.userId" icon color="satisfyIcon">
+                <v-btn v-if="!isMyGoal" icon color="satisfyIcon">
                   <v-icon>mdi-emoticon-outline</v-icon>
                 </v-btn>
-                <v-btn
-                  v-if="Iam.id == goal.userId"
-                  icon
-                  @click="openDeleteModal(commit)"
-                >
+                <v-btn v-if="isMyGoal" icon @click="openDeleteModal(commit)">
                   <v-icon>mdi-delete-outline</v-icon>
                 </v-btn>
               </div>
@@ -116,6 +112,10 @@ export default Vue.extend({
     },
     paginationLength(): number {
       return Math.ceil(this.commits.length / this.pageSize)
+    },
+    isMyGoal(): boolean {
+      if (!this.goal) return false
+      return this.goal.userId === this.Iam.id
     }
   },
   watch: {

--- a/client/components/organisms/goals/index/CommitsTable.vue
+++ b/client/components/organisms/goals/index/CommitsTable.vue
@@ -80,6 +80,10 @@ export default Vue.extend({
     goal: {
       type: Object as PropType<GoalSerializer>,
       required: true
+    },
+    isMyGoal: {
+      type: Boolean,
+      required: true
     }
   },
   data() {
@@ -112,10 +116,6 @@ export default Vue.extend({
     },
     paginationLength(): number {
       return Math.ceil(this.commits.length / this.pageSize)
-    },
-    isMyGoal(): boolean {
-      if (!this.goal) return false
-      return this.goal.userId === this.Iam.id
     }
   },
   watch: {

--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -16,7 +16,7 @@
           >
           {{ goal.label }}
         </v-chip>
-        <v-btn icon @click="goalEditDialog = true">
+        <v-btn v-if="Iam.id == goal.userId" icon @click="goalEditDialog = true">
           <v-icon midium>mdi-cog</v-icon>
         </v-btn>
         <GoalEditDialog v-model="goalEditDialog" :goal="goal" />

--- a/client/components/organisms/goals/index/GoalDetailHeader.vue
+++ b/client/components/organisms/goals/index/GoalDetailHeader.vue
@@ -16,7 +16,7 @@
           >
           {{ goal.label }}
         </v-chip>
-        <v-btn v-if="Iam.id == goal.userId" icon @click="goalEditDialog = true">
+        <v-btn v-if="isMyGoal" icon @click="goalEditDialog = true">
           <v-icon midium>mdi-cog</v-icon>
         </v-btn>
         <GoalEditDialog v-model="goalEditDialog" :goal="goal" />
@@ -56,6 +56,10 @@ export default Vue.extend({
     },
     commits: {
       type: Array as PropType<CommitSerializer[]>,
+      required: true
+    },
+    isMyGoal: {
+      type: Boolean,
       required: true
     }
   },

--- a/client/pages/goals/_id/index.vue
+++ b/client/pages/goals/_id/index.vue
@@ -1,14 +1,15 @@
 <template>
   <v-row justify="center">
     <v-col cols="12" md="10">
-      <GoalDetailHeader v-if="goal" :goal="goal" :commits="commits" />
+      <GoalDetailHeader
+        v-if="goal"
+        :goal="goal"
+        :commits="commits"
+        :is-my-goal="isMyGoal"
+      />
       <v-row justify="space-between" class="mx-1 mt-3">
         <p class="text-h4 primary--text font-weight-bold">学習記録</p>
-        <v-btn
-          v-if="goal && Iam.id === goal.userId"
-          color="white"
-          @click="createCommitDialog = true"
-        >
+        <v-btn v-if="isMyGoal" color="white" @click="createCommitDialog = true">
           <v-icon>mdi-plus</v-icon>
         </v-btn>
       </v-row>
@@ -18,6 +19,7 @@
         :commits="commits"
         :goal="goal"
         :create-commit-dialog="createCommitDialog"
+        :is-my-goal="isMyGoal"
         @close="createCommitDialog = false"
       />
     </v-col>
@@ -59,6 +61,10 @@ export default Vue.extend({
       return [
         ...goalStore.goalsGetter.map((g) => ({ text: g.title, value: g.id }))
       ]
+    },
+    isMyGoal(): boolean {
+      if (!this.goal) return false
+      return this.goal.userId === this.Iam.id
     }
   },
   async created() {

--- a/client/pages/goals/_id/index.vue
+++ b/client/pages/goals/_id/index.vue
@@ -4,7 +4,11 @@
       <GoalDetailHeader v-if="goal" :goal="goal" :commits="commits" />
       <v-row justify="space-between" class="mx-1 mt-3">
         <p class="text-h4 primary--text font-weight-bold">学習記録</p>
-        <v-btn color="white" @click="createCommitDialog = true">
+        <v-btn
+          v-if="goal && Iam.id === goal.userId"
+          color="white"
+          @click="createCommitDialog = true"
+        >
           <v-icon>mdi-plus</v-icon>
         </v-btn>
       </v-row>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/qWuttiLY

## :memo: 概要
他人の目標詳細画面における不要なボタンの非表示化

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] ほかのユーザーの目標詳細画面を見ると歯車とプラスボタンとDeleteボタンが表示されない
- [x] 自分の目標詳細画面では表示される
