### PR TITLE
検索画面でのゴールの累計学習時間、累計学習数の表示

### DIFF
--- a/api/src/search/searches.service.ts
+++ b/api/src/search/searches.service.ts
@@ -62,6 +62,7 @@ export class SearchesService {
       .where('goal.title LIKE :title', { title: `%${keyword}%` })
       .andWhere('goal.isPublic = true')
       .leftJoinAndSelect('goal.user', 'user')
+      .leftJoinAndSelect('goal.commits', 'commits')
       .getMany();
   }
 }

--- a/client/components/organisms/search/SearchGoalList.vue
+++ b/client/components/organisms/search/SearchGoalList.vue
@@ -24,11 +24,13 @@
           <v-list-item-subtitle class="mt-2 ml-3">
             <div>
               <span class="mr-3">
-                <v-icon color="primary">mdi-timer-outline</v-icon>99h99m
+                <v-icon color="primary">mdi-timer-outline</v-icon
+                >{{ goal.totalTime | toJPHm }}
               </span>
-              <span><v-icon color="primary">mdi-flag</v-icon>99</span>
-
-              <span><v-icon color="primary">mdi-pencil</v-icon>999</span>
+              <span
+                ><v-icon color="primary">mdi-pencil</v-icon
+                >{{ goal.commits.length }}</span
+              >
             </div>
           </v-list-item-subtitle>
         </v-list-item-content>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/oSC7HuaR

## :memo: 概要
- 検索画面でのゴールの累計学習時間、累計学習数の表示をしました

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [x] CIが通ること
- [x] 検索結果画面で、ゴールの累計学習時間、累計学習数が反映されていること
