### PR TITLE
まだできていないリアクションボタンを隠す（発表のため）

### DIFF
--- a/client/components/organisms/goals/index/CommitsTable.vue
+++ b/client/components/organisms/goals/index/CommitsTable.vue
@@ -21,20 +21,22 @@
                   <p>
                     {{ `${commit.studyHours}時間${commit.studyMinutes}分` }}
                   </p>
-                  <div>
+                  <!-- TODO: リアクション機能が出来てから表示する（発表のときにあると不完全感があるので、消します） -->
+                  <!-- <div>
                     <v-chip small>
                       <v-icon>mdi-emoticon-happy-outline</v-icon>
                     </v-chip>
                     <v-chip small>
                       <v-icon>mdi-emoticon-kiss-outline</v-icon>
                     </v-chip>
-                  </div>
+                  </div> -->
                 </div>
               </div>
               <div class="d-flex align-self-center">
-                <v-btn v-if="!isMyGoal" icon color="satisfyIcon">
+                <!-- TODO: リアクション機能が出来てから表示する（発表のときにあると不完全感があるので、消します） -->
+                <!-- <v-btn v-if="!isMyGoal" icon color="satisfyIcon">
                   <v-icon>mdi-emoticon-outline</v-icon>
-                </v-btn>
+                </v-btn> -->
                 <v-btn v-if="isMyGoal" icon @click="openDeleteModal(commit)">
                   <v-icon>mdi-delete-outline</v-icon>
                 </v-btn>


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/0EZbKkKT

## :memo: 概要
- 目標詳細ページの学習記録のところで、リアクション機能はまだ実装していないので、コメントアウトします

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [x] 目標詳細ページの学習記録のところで、リアクションボタンとリアクションチップが非表示になっていること（本人、他人問わず）