### PR TITLE
プロフィールの右下の学習記録のところの、月の並びを修正

### DIFF
--- a/client/components/organisms/profile/CommitsTable.vue
+++ b/client/components/organisms/profile/CommitsTable.vue
@@ -3,7 +3,9 @@
     <div v-if="goalSummary">
       <!-- サンプル用に適当に２回数ループしとく -->
       <v-card
-        v-for="month in Object.keys(goalSummary)"
+        v-for="month in Object.keys(goalSummary).sort(
+          (a, b) => new Date(b) - new Date(a)
+        )"
         :key="month"
         tile
         class="pa-0 mainText--text"


### PR DESCRIPTION
## :ticket: チケット
https://trello.com/c/5Ivg0sXU

## :memo: 概要
プロフィールの右下の学習記録のところの、月の並びを修正

## :stuck_out_tongue: やってないこと
（この PR ではやってないことなどを明記しよう。相談の上、あえて他のPRで対応する予定のこととか）

## :heavy_check_mark: 動作確認
（実装した個々の機能の再現方法を明記し、開発者・レビュワー共に確認するのだ！）
- [ ] CIが通ること
- [ ] プロフィールページの、右下学習記録のところで、月の降順にサマリーがまとめられていること
